### PR TITLE
Enable password login and OTP resend for existing users

### DIFF
--- a/app/pages/auth.vue
+++ b/app/pages/auth.vue
@@ -50,14 +50,12 @@
             />
           </div>
 
-          <button type="submit" class="btn btn-primary" :disabled="loading">
-            {{ loading ? 'در حال ورود...' : 'ورود' }}
+          <button type="button" @click="requestOTP" class="btn-link">
+            ورود با کد یکبار مصرف
           </button>
 
-          <div class="divider">یا</div>
-
-          <button type="button" @click="requestOTP" class="btn btn-secondary">
-            ورود با کد یکبار مصرف
+          <button type="submit" class="btn btn-primary" :disabled="loading">
+            {{ loading ? 'در حال ورود...' : 'ورود' }}
           </button>
         </form>
 
@@ -194,12 +192,10 @@ const handleIdentifier = async () => {
     if (checkResult.success && checkResult.data) {
       userHasPassword.value = checkResult.data.has_password || false
       
-      // تصمیم‌گیری بر اساس نوع identifier و وجود پسورد
-      if (isEmail.value && userHasPassword.value) {
-        // اگر ایمیل است و پسورد دارد، صفحه پسورد را نشان بده
+      // اگر کاربر پسورد دارد (ایمیل یا شماره)، مرحله پسورد را نمایش بده؛ در غیر این صورت OTP
+      if (userHasPassword.value) {
         step.value = 'password'
       } else {
-        // در غیر این صورت، مستقیم OTP ارسال کن
         await requestOTP()
       }
     } else {


### PR DESCRIPTION
Allow users with existing passwords (email or phone) to log in via password, offering an OTP fallback link.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b19c84f-4546-4d2f-91de-e3a00e67cbf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b19c84f-4546-4d2f-91de-e3a00e67cbf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

