### PR TITLE
Fix book list display on dashboard

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -245,6 +245,7 @@ export const useAuth = () => {
     loading: readonly(loading),
     initialized: readonly(initialized),
     isLoggedIn,
+    api,
     checkUserIdentifier,
     loginPassword,
     sendOTP,

--- a/app/pages/dashboard/books/[slug].vue
+++ b/app/pages/dashboard/books/[slug].vue
@@ -57,10 +57,10 @@ const fetchBook = async () => {
   if (!slug.value) return
   loading.value = true
   try {
-    const res = await api(`/api/v1/books/${slug.value}`)
+    const res = await api(`/v1/books/${slug.value}`)
     book.value = res.data || res.book || res
 
-    const rel = await api(`/api/v1/books/${slug.value}/related`)
+    const rel = await api(`/v1/books/${slug.value}/related`)
     related.value = rel.data || rel.items || []
   } catch (e) {
     showError('خطا در دریافت اطلاعات کتاب')

--- a/app/pages/dashboard/books/index.vue
+++ b/app/pages/dashboard/books/index.vue
@@ -75,7 +75,7 @@ const fetchBooks = async () => {
       ...(q.value ? { q: q.value } : {})
     })
 
-    const res = await api(`/api/v1/books?${params.toString()}`)
+    const res = await api(`/v1/books?${params.toString()}`)
     books.value = res.data || res.items || res.results || []
 
     // try common meta shapes


### PR DESCRIPTION
Export `api` helper and correct API endpoint paths to fix book list display on the dashboard.

The `api` helper was not exported from `useAuth.ts`, making it `undefined` when used. Additionally, API endpoints in the book dashboard pages were incorrectly prefixed with `/api/v1/` which, when combined with the existing `apiBase` configuration, resulted in a malformed URL like `/api/api/v1/`, preventing successful data fetching.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf0ede53-184f-4faa-809d-b46b56c14122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf0ede53-184f-4faa-809d-b46b56c14122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

