### PR TITLE
Fix invalid end tag in vue files

### DIFF
--- a/app/pages/save-token.vue
+++ b/app/pages/save-token.vue
@@ -247,4 +247,3 @@ pre {
   color: white;
 }
 </style>
-</template>

--- a/app/pages/test-api.vue
+++ b/app/pages/test-api.vue
@@ -211,4 +211,3 @@ pre {
   background: #5a67d8;
 }
 </style>
-</template>

--- a/app/pages/test-auth.vue
+++ b/app/pages/test-auth.vue
@@ -97,4 +97,3 @@ li {
   background: #5a67d8;
 }
 </style>
-</template>


### PR DESCRIPTION
Fix: Remove extraneous `</template>` tags to resolve "Invalid end tag" errors.

The "Invalid end tag" errors in `test-api.vue`, `save-token.vue`, and `test-auth.vue` were caused by `</template>` tags incorrectly appearing after the `</style>` tags. This PR removes these misplaced tags to adhere to the correct Vue Single File Component structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3ea54ac-1cb3-41ef-8f27-dcd270abf165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3ea54ac-1cb3-41ef-8f27-dcd270abf165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

