### PR TITLE
Fix invalid end tag in vue files

### DIFF
--- a/app/pages/save-token.vue
+++ b/app/pages/save-token.vue
@@ -247,4 +247,3 @@ pre {
   color: white;
 }
 </style>
-</template>

--- a/app/pages/test-api.vue
+++ b/app/pages/test-api.vue
@@ -211,4 +211,3 @@ pre {
   background: #5a67d8;
 }
 </style>
-</template>

--- a/app/pages/test-auth.vue
+++ b/app/pages/test-auth.vue
@@ -97,4 +97,3 @@ li {
   background: #5a67d8;
 }
 </style>
-</template>


### PR DESCRIPTION
Remove redundant `</template>` tags to fix "Invalid end tag" errors during Nuxt dev server startup.

Vue Single File Components (SFCs) require a specific structure for `<template>`, `<script>`, and `<style>` blocks. An extra `</template>` tag after the `</style>` block caused a parsing error in the Vite/Vue compiler, preventing the dev server from starting correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-642b752a-6541-4c6c-a136-41aff4c01a19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-642b752a-6541-4c6c-a136-41aff4c01a19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

