### PR TITLE
Fix 404 error for books page

### DIFF
--- a/app/pages/books.vue
+++ b/app/pages/books.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Books page</div>
+</template>


### PR DESCRIPTION
Create `app/pages/books.vue` to resolve the `/books` route and prevent a 404 error.

---
<a href="https://cursor.com/background-agent?bcId=bc-01425edd-1fd5-4eb1-9440-42e808311ac1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01425edd-1fd5-4eb1-9440-42e808311ac1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

