### PR TITLE
Fix username update on profile page

### DIFF
--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -977,8 +977,9 @@ const verifyCode = async () => {
   }
 }
 
-const confirmUsernameChange = () => {
+const confirmUsernameChange = async () => {
   showUsernameWarning.value = false
+  await updateProfile()
 }
 
 const cancelUsernameChange = () => {


### PR DESCRIPTION
Call `updateProfile` when username change is confirmed to ensure username is updated.

The previous implementation of `confirmUsernameChange` only closed the warning modal without triggering the actual profile update, preventing username changes from being persisted. This change ensures that when a user confirms a username change, the `updateProfile` function is invoked, sending the new username to the backend.

---
<a href="https://cursor.com/background-agent?bcId=bc-2630de9e-baca-40d3-8253-1818b5e5fe6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2630de9e-baca-40d3-8253-1818b5e5fe6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

