### PR TITLE
feat(profile): Implement username change rate limit UI

### DIFF
--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -16,7 +16,12 @@ interface User {
   created_at?: string
   preferred_method?: string
   locked_until?: string
-  password?: boolean
+  password?: boolean // This might be a simplified check from older API versions
+  has_password?: boolean // More explicit check
+  username_last_changed?: string | null
+  province_id?: number | null
+  city_id?: number | null
+  address?: string | null
 }
 
 export const useAuthStore = defineStore('auth', {


### PR DESCRIPTION
Implements the frontend logic for the 365-day username change limitation based on the API documentation.

Key changes:
- In `profile.vue`, the logic now catches the specific 422 error from the server when a username change is attempted within the restricted period.
- A dedicated error message is now displayed directly below the username field, showing the user how many days remain until the next possible change.
- The username input field is disabled if the server returns this error or if the initial data shows the user is within the cooldown period.
- The `User` interface in `auth.ts` has been updated to include missing fields like `username_last_changed` and `has_password` for better type safety.
- The `hasPassword` computed property in `profile.vue` has been refactored for clarity and maintainability.