### PR TITLE
fix(profile): Correct verification endpoints and username logic

### DIFF
--- a/app/composables/useProfile.ts
+++ b/app/composables/useProfile.ts
@@ -95,9 +95,9 @@ export const useProfile = () => {
    */
   const sendEmailVerification = async (email: string) => {
     try {
-      console.log('Sending email verification to:', email)
-      const response = await api.post('/auth/email/send-verification', { email })
-      console.log('Email verification sent:', response)
+      console.log('Sending OTP to email:', email)
+      const response = await api.post('/auth/send-otp', { identifier: email })
+      console.log('Email OTP sent:', response)
       return response
     } catch (error) {
       console.error('Error sending email verification:', error)
@@ -110,8 +110,8 @@ export const useProfile = () => {
    */
   const verifyEmail = async (email: string, code: string) => {
     try {
-      console.log('Verifying email:', email, 'with code:', code)
-      const response = await api.post('/auth/email/verify', { email, code })
+      console.log('Verifying email OTP:', email, 'with code:', code)
+      const response = await api.post('/auth/verify-otp', { identifier: email, otp: code })
       console.log('Email verification response:', response)
       return response
     } catch (error) {
@@ -125,9 +125,9 @@ export const useProfile = () => {
    */
   const sendPhoneVerification = async (phone: string) => {
     try {
-      console.log('Sending phone verification to:', phone)
-      const response = await api.post('/auth/phone/send-verification', { phone })
-      console.log('Phone verification sent:', response)
+      console.log('Sending OTP to phone:', phone)
+      const response = await api.post('/auth/send-otp', { identifier: phone })
+      console.log('Phone OTP sent:', response)
       return response
     } catch (error) {
       console.error('Error sending phone verification:', error)
@@ -140,8 +140,8 @@ export const useProfile = () => {
    */
   const verifyPhone = async (phone: string, code: string) => {
     try {
-      console.log('Verifying phone:', phone, 'with code:', code)
-      const response = await api.post('/auth/phone/verify', { phone, code })
+      console.log('Verifying phone OTP:', phone, 'with code:', code)
+      const response = await api.post('/auth/verify-otp', { identifier: phone, otp: code })
       console.log('Phone verification response:', response)
       return response
     } catch (error) {


### PR DESCRIPTION
This commit addresses two separate issues on the profile page:

1.  It corrects the phone and email verification flow by updating the API calls in `useProfile.ts` to use the correct endpoints (`/auth/send-otp` and `/auth/verify-otp`) as specified in the API documentation. This allows users to add and verify a new contact method from their profile.

2.  It implements the definitive fix for the username change restriction. The logic now relies on the `days_until_username_change` field provided by the backend, ensuring the input field is disabled and the correct cooldown message is displayed on page load. This removes all fragile frontend date calculations.

All related computed properties and template logic have been simplified to reflect this more robust approach.