### PR TITLE
fix(books): Correct API URL for fetching books

### DIFF
--- a/app/pages/books.vue
+++ b/app/pages/books.vue
@@ -68,7 +68,7 @@ const api = useApi()
 const fetchBooks = async (page) => {
   loading.value = true
   try {
-    const response = await api.get('/api/v1/books', {
+    const response = await api.get('/v1/books', {
       params: {
         per_page: 10,
         sort: 'newest',


### PR DESCRIPTION
The /books page was not displaying any books because the API call to fetch them was using an incorrect URL.

The `useApi` composable automatically prepends the `/api` base path to all requests. The call in `books.vue` was also including `/api`, resulting in a duplicated path (`/api/api/v1/books`).

This commit removes the redundant `/api` prefix from the `api.get()` call in `app/pages/books.vue`, ensuring the correct endpoint (`/api/v1/books`) is called.