### PR TITLE
feat: Implement admin pages for user and role management

### DIFF
--- a/app/components/admin/RoleModal.vue
+++ b/app/components/admin/RoleModal.vue
@@ -1,0 +1,102 @@
+<template>
+  <div v-if="show" class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full" @click.self="close">
+    <div class="relative top-20 mx-auto p-5 border w-full max-w-2xl shadow-lg rounded-md bg-white">
+      <div class="mt-3 text-center">
+        <h3 class="text-lg leading-6 font-medium text-gray-900">{{ isEditMode ? 'ویرایش نقش' : 'ایجاد نقش جدید' }}</h3>
+        <div class="mt-2 px-7 py-3">
+          <form @submit.prevent="submitForm" class="text-right">
+            <div class="mb-4">
+              <label for="display_name" class="block text-sm font-medium text-gray-700">نام نمایشی</label>
+              <input type="text" v-model="formData.display_name" id="display_name" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" required>
+            </div>
+            <div class="mb-4">
+              <label for="name" class="block text-sm font-medium text-gray-700">نام سیستمی (انگلیسی، بدون فاصله)</label>
+              <input type="text" v-model="formData.name" id="name" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" :disabled="isEditMode" required>
+            </div>
+            <div class="mb-4">
+              <label for="description" class="block text-sm font-medium text-gray-700">توضیحات</label>
+              <textarea v-model="formData.description" id="description" rows="3" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"></textarea>
+            </div>
+
+            <div class="mb-4">
+              <h4 class="text-md font-medium text-gray-800 mb-2">دسترسی‌ها</h4>
+              <div v-for="(group, groupName) in allPermissions" :key="groupName" class="mb-3">
+                <h5 class="font-bold text-gray-700">{{ groupName }}</h5>
+                <div class="grid grid-cols-2 md:grid-cols-3 gap-2 mt-1">
+                  <div v-for="permission in group" :key="permission.id">
+                    <label class="inline-flex items-center">
+                      <input type="checkbox" class="form-checkbox h-5 w-5 text-indigo-600" :value="permission.id" v-model="formData.permission_ids">
+                      <span class="mr-2 text-gray-700">{{ permission.display_name }}</span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="items-center px-4 py-3">
+              <button type="submit" class="px-4 py-2 bg-green-500 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-300">
+                ذخیره
+              </button>
+              <button type="button" @click="close" class="ml-2 px-4 py-2 bg-gray-500 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-300">
+                انصراف
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, defineProps, defineEmits } from 'vue';
+import type { Role, Permission, CreateRolePayload } from '~/composables/useAuthApi';
+
+const props = defineProps<{
+  show: boolean;
+  role: Role | null;
+  allPermissions: Record<string, Permission[]>;
+}>();
+
+const emit = defineEmits(['close', 'save']);
+
+const isEditMode = ref(false);
+
+const initialFormData: CreateRolePayload & { permission_ids: number[] } = {
+  name: '',
+  display_name: '',
+  description: '',
+  permission_ids: [],
+};
+const formData = ref({ ...initialFormData });
+
+watch(() => props.role, (newRole) => {
+  if (newRole) {
+    isEditMode.value = true;
+    formData.value = {
+      name: newRole.name,
+      display_name: newRole.display_name,
+      description: newRole.description || '',
+      permission_ids: newRole.permissions?.map(p => p.id) || [],
+    };
+  } else {
+    isEditMode.value = false;
+    formData.value = { ...initialFormData };
+  }
+}, { immediate: true });
+
+
+function close() {
+  emit('close');
+}
+
+function submitForm() {
+  emit('save', formData.value);
+}
+</script>
+
+<style scoped>
+.form-checkbox {
+  border-radius: 0.25rem;
+}
+</style>

--- a/app/components/admin/UserRoleModal.vue
+++ b/app/components/admin/UserRoleModal.vue
@@ -1,0 +1,87 @@
+<template>
+  <div v-if="show" class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full" @click.self="close">
+    <div class="relative top-20 mx-auto p-5 border w-full max-w-lg shadow-lg rounded-md bg-white">
+      <div class="mt-3">
+        <h3 class="text-lg leading-6 font-medium text-gray-900 text-center">
+          مدیریت نقش‌های کاربر: <span class="font-bold">{{ user?.name }}</span>
+        </h3>
+        <div class="mt-4 px-7 py-3">
+          <form @submit.prevent="submitForm" class="text-right">
+            <div class="mb-4">
+              <h4 class="text-md font-medium text-gray-800 mb-2">نقش‌های موجود</h4>
+              <p class="text-sm text-gray-500 mb-3">نقش‌های مورد نظر برای این کاربر را انتخاب کنید.</p>
+              <div class="grid grid-cols-2 gap-3">
+                <div v-for="role in allRoles" :key="role.id">
+                  <label class="inline-flex items-center">
+                    <input type="checkbox" class="form-checkbox h-5 w-5 text-indigo-600" :value="role.id" v-model="selectedRoleIds">
+                    <span class="mr-2 text-gray-700">{{ role.display_name }}</span>
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <div class="items-center px-4 py-3 text-center">
+              <button type="submit" class="px-4 py-2 bg-green-500 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-300">
+                ذخیره تغییرات
+              </button>
+              <button type="button" @click="close" class="ml-2 px-4 py-2 bg-gray-500 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-300">
+                انصراف
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, defineProps, defineEmits } from 'vue';
+
+// Assuming User and Role types are defined elsewhere and imported
+// For now, let's define them locally for clarity.
+interface User {
+  id: number;
+  name: string;
+  roles?: Role[];
+}
+interface Role {
+  id: number;
+  name: string;
+  display_name: string;
+}
+
+const props = defineProps<{
+  show: boolean;
+  user: User | null;
+  allRoles: Role[];
+}>();
+
+const emit = defineEmits(['close', 'save']);
+
+const selectedRoleIds = ref<number[]>([]);
+
+// Watch for changes in the user prop to initialize the selected roles
+watch(() => props.user, (currentUser) => {
+  if (currentUser && currentUser.roles) {
+    selectedRoleIds.value = currentUser.roles.map(role => role.id);
+  } else {
+    selectedRoleIds.value = [];
+  }
+}, { immediate: true, deep: true });
+
+function close() {
+  emit('close');
+}
+
+function submitForm() {
+  // Emit the array of selected role IDs to the parent component
+  emit('save', selectedRoleIds.value);
+}
+</script>
+
+<style scoped>
+.form-checkbox {
+  border-radius: 0.25rem;
+}
+</style>

--- a/app/composables/useAuthApi.ts
+++ b/app/composables/useAuthApi.ts
@@ -2,34 +2,87 @@
 import { useAuthStore } from '~/stores/auth'
 import { useApi } from '~/composables/useApi'
 
+// Define interfaces for our data structures for type safety
+export interface Role {
+  id: number;
+  name: string;
+  display_name: string;
+  description?: string;
+  permissions?: Permission[];
+}
+
+export interface Permission {
+  id: number;
+  name: string;
+  display_name: string;
+  module: string;
+}
+
+export interface CreateRolePayload {
+  name: string;
+  display_name: string;
+  description?: string;
+  permission_ids: number[];
+}
+
+export interface UpdateRolePayload {
+  display_name: string;
+  description?: string;
+}
+
+
 export const useAuthApi = () => {
   const authStore = useAuthStore()
   const token = authStore.token
 
   if (!token) {
+    // In a real app, you might want to redirect to login here
     console.warn('Auth token is not available. API calls may fail.')
-    // You might want to handle this case, e.g., by redirecting to login
   }
 
   const api = useApi(token)
 
   return {
-    getRoles: () => {
-      return api.get('/admin/roles')
+    // ====== Role Management ======
+    getRoles: (withPermissions: boolean = false) => {
+      const url = withPermissions ? '/roles?with_permissions=true' : '/roles';
+      return api.get(url);
     },
 
+    getRole: (id: number) => {
+      return api.get(`/roles/${id}`);
+    },
+
+    createRole: (data: CreateRolePayload) => {
+      return api.post('/roles', data);
+    },
+
+    updateRole: (id: number, data: UpdateRolePayload) => {
+      return api.put(`/roles/${id}`, data);
+    },
+
+    deleteRole: (id: number) => {
+      return api.delete(`/roles/${id}`);
+    },
+
+    // ====== Permission Management ======
     getPermissions: () => {
-      return api.get('/admin/permissions')
-    },
-
-    getRolePermissions: (roleId: number) => {
-      return api.get(`/admin/roles/${roleId}/permissions`)
+      return api.get('/permissions');
     },
 
     updateRolePermissions: (roleId: number, permissionIds: number[]) => {
-      return api.put(`/admin/roles/${roleId}/permissions`, {
-        permissions: permissionIds
-      })
+      return api.put(`/permissions/role/${roleId}`, {
+        permission_ids: permissionIds
+      });
+    },
+
+    // ====== User Role Management ======
+    assignRoleToUser: (userId: number, roleId: number) => {
+      return api.post(`/roles/user/${userId}/assign`, { role_id: roleId });
+    },
+
+    removeRoleFromUser: (userId: number, roleId: number) => {
+      return api.post(`/roles/user/${userId}/remove`, { role_id: roleId });
     }
   }
 }

--- a/app/pages/admin/roles.vue
+++ b/app/pages/admin/roles.vue
@@ -1,0 +1,187 @@
+<template>
+  <div class="p-4 md:p-6">
+    <h1 class="text-2xl font-bold mb-4">مدیریت نقش‌ها و دسترسی‌ها</h1>
+
+    <!-- Action Buttons -->
+    <div class="mb-4">
+      <button @click="openCreateModal" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded shadow">
+        ایجاد نقش جدید
+      </button>
+    </div>
+
+    <!-- Loading and Error States -->
+    <div v-if="isLoading" class="text-center py-4">
+      <p>در حال بارگذاری اطلاعات...</p>
+    </div>
+    <div v-if="error" class="text-center py-4 text-red-500">
+      <p>خطا در دریافت اطلاعات: {{ error.message }}</p>
+    </div>
+
+    <!-- Roles Table -->
+    <div v-if="!isLoading && !error" class="shadow overflow-x-auto border-b border-gray-200 sm:rounded-lg">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+              نام نمایشی
+            </th>
+            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+              توضیحات
+            </th>
+            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+              عملیات
+            </th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <tr v-if="roles.length === 0">
+            <td colspan="3" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
+              هیچ نقشی یافت نشد.
+            </td>
+          </tr>
+          <tr v-for="role in roles" :key="role.id">
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+              {{ role.display_name }}
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              {{ role.description }}
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+              <button @click="openEditModal(role)" class="text-indigo-600 hover:text-indigo-900">ویرایش</button>
+              <button @click="handleDeleteRole(role.id)" class="text-red-600 hover:text-red-900 mr-4">حذف</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Create/Edit Modal -->
+    <RoleModal
+      :show="isModalOpen"
+      :role="currentRole"
+      :all-permissions="groupedPermissions"
+      @close="closeModal"
+      @save="handleSaveRole"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useAuthApi } from '~/composables/useAuthApi';
+import type { Role, Permission, CreateRolePayload, UpdateRolePayload } from '~/composables/useAuthApi';
+import RoleModal from '~/components/admin/RoleModal.vue';
+
+definePageMeta({
+  layout: 'admin', // Assuming an admin layout exists
+  middleware: ['auth'], // Assuming an auth middleware exists
+});
+
+const api = useAuthApi();
+
+const roles = ref<Role[]>([]);
+const groupedPermissions = ref<Record<string, Permission[]>>({});
+const isLoading = ref(true);
+const error = ref<Error | null>(null);
+
+const isModalOpen = ref(false);
+const currentRole = ref<Role | null>(null);
+
+async function fetchRoles() {
+  try {
+    isLoading.value = true;
+    // Fetch roles with their assigned permissions
+    const response = await api.getRoles(true);
+    roles.value = response.data;
+  } catch (e) {
+    error.value = e as Error;
+    console.error("Failed to fetch roles:", e);
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+async function fetchPermissions() {
+  try {
+    const response = await api.getPermissions();
+    // Group permissions by module
+    groupedPermissions.value = response.data.reduce((acc, permission) => {
+      const module = permission.module || 'General';
+      if (!acc[module]) {
+        acc[module] = [];
+      }
+      acc[module].push(permission);
+      return acc;
+    }, {});
+  } catch (e) {
+    console.error("Failed to fetch permissions:", e);
+    error.value = e as Error; // Also set error if permissions fail
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([
+    fetchRoles(),
+    fetchPermissions()
+  ]);
+});
+
+function openCreateModal() {
+  currentRole.value = null;
+  isModalOpen.value = true;
+}
+
+function openEditModal(role: Role) {
+  currentRole.value = role;
+  isModalOpen.value = true;
+}
+
+function closeModal() {
+  isModalOpen.value = false;
+  currentRole.value = null;
+}
+
+async function handleSaveRole(formData: CreateRolePayload & { permission_ids: number[] }) {
+  try {
+    if (currentRole.value) {
+      // Edit mode
+      const roleId = currentRole.value.id;
+      const updatePayload: UpdateRolePayload = {
+        display_name: formData.display_name,
+        description: formData.description,
+      };
+      await api.updateRole(roleId, updatePayload);
+      await api.updateRolePermissions(roleId, formData.permission_ids);
+      alert('نقش با موفقیت به‌روزرسانی شد.');
+    } else {
+      // Create mode
+      const createPayload: CreateRolePayload = {
+        name: formData.name,
+        display_name: formData.display_name,
+        description: formData.description,
+        permission_ids: formData.permission_ids,
+      };
+      await api.createRole(createPayload);
+      alert('نقش با موفقیت ایجاد شد.');
+    }
+    closeModal();
+    await fetchRoles(); // Refresh the list
+  } catch (e) {
+    console.error('Failed to save role:', e);
+    alert('خطا در ذخیره‌سازی نقش. لطفاً جزئیات را در کنسول بررسی کنید.');
+  }
+}
+
+async function handleDeleteRole(roleId: number) {
+  if (confirm('آیا از حذف این نقش اطمینان دارید؟ این عمل قابل بازگشت نیست.')) {
+    try {
+      await api.deleteRole(roleId);
+      alert('نقش با موفقیت حذف شد.');
+      roles.value = roles.value.filter(r => r.id !== roleId);
+    } catch (e) {
+      console.error('Failed to delete role:', e);
+      alert('خطا در حذف نقش.');
+    }
+  }
+}
+</script>

--- a/app/pages/admin/users.vue
+++ b/app/pages/admin/users.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="p-4 md:p-6">
+    <h1 class="text-2xl font-bold mb-4">مدیریت کاربران</h1>
+
+    <!-- Search and Filter -->
+    <div class="mb-4">
+      <input
+        type="text"
+        placeholder="جستجو بر اساس نام، ایمیل و..."
+        class="w-full md:w-1/3 px-3 py-2 border border-gray-300 rounded-md"
+        @input="handleSearch"
+      />
+    </div>
+
+    <!-- Loading and Error States -->
+    <div v-if="isLoading" class="text-center py-4">
+      <p>در حال بارگذاری اطلاعات...</p>
+    </div>
+    <div v-if="error" class="text-center py-4 text-red-500">
+      <p>خطا در دریافت اطلاعات: {{ error.message }}</p>
+      <p class="text-sm text-gray-600 mt-2">
+        (توجه: این صفحه نیازمند اندپوینتی برای دریافت لیست کاربران است که هنوز ارائه نشده است. از داده‌های موقت استفاده می‌شود.)
+      </p>
+    </div>
+
+    <!-- Users Table -->
+    <div v-if="!isLoading" class="shadow overflow-x-auto border-b border-gray-200 sm:rounded-lg">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">نام</th>
+            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">ایمیل</th>
+            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">نقش‌ها</th>
+            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">عملیات</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <tr v-if="users.length === 0">
+            <td colspan="4" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
+              کاربری یافت نشد.
+            </td>
+          </tr>
+          <tr v-for="user in users" :key="user.id">
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ user.name }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ user.email }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <span v-for="role in user.roles" :key="role.id" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800 mr-1">
+                {{ role.display_name }}
+              </span>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+              <button @click="openRoleModal(user)" class="text-indigo-600 hover:text-indigo-900">مدیریت نقش‌ها</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- User Role Modal -->
+    <UserRoleModal
+      :show="isModalOpen"
+      :user="currentUser"
+      :all-roles="allRoles"
+      @close="closeModal"
+      @save="handleRoleSave"
+    />
+
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useAuthApi, type Role } from '~/composables/useAuthApi';
+import UserRoleModal from '~/components/admin/UserRoleModal.vue';
+
+// Define a placeholder user type that includes roles
+interface User {
+  id: number;
+  name: string;
+  email: string;
+  roles: Role[];
+}
+
+definePageMeta({
+  layout: 'admin',
+  middleware: ['auth'],
+});
+
+const api = useAuthApi();
+
+// State
+const users = ref<User[]>([]);
+const allRoles = ref<Role[]>([]);
+const isLoading = ref(true);
+const error = ref<Error | null>(null);
+
+const isModalOpen = ref(false);
+const currentUser = ref<User | null>(null);
+
+// Fetch all available roles for the modal
+async function fetchAllRoles() {
+  try {
+    const response = await api.getRoles();
+    allRoles.value = response.data;
+  } catch (e) {
+    console.error("Failed to fetch roles for modal:", e);
+  }
+}
+
+// Fetch users (currently placeholder)
+async function fetchUsers() {
+  isLoading.value = true;
+  // This is where the real API call will go.
+  // For now, we use placeholder data and simulate a delay.
+  // We'll also set an error to inform that the real API is missing.
+  setTimeout(() => {
+    users.value = [
+      { id: 1, name: 'مدیر سیستم', email: 'admin@example.com', roles: allRoles.value.filter(r => r.name === 'admin' || r.id === 1) },
+      { id: 2, name: 'کاربر تستی', email: 'test@example.com', roles: allRoles.value.filter(r => r.name === 'user' || r.id === 2) },
+    ];
+    error.value = new Error("API endpoint for fetching users is not available.");
+    isLoading.value = false;
+  }, 500);
+}
+
+onMounted(async () => {
+  isLoading.value = true;
+  await fetchAllRoles();
+  await fetchUsers(); // This will run after roles are fetched
+});
+
+function handleSearch(event: Event) {
+  const target = event.target as HTMLInputElement;
+  console.log('Searching for:', target.value);
+  // Search logic will be implemented here
+}
+
+function openRoleModal(user: User) {
+  currentUser.value = user;
+  isModalOpen.value = true;
+}
+
+function closeModal() {
+  isModalOpen.value = false;
+  currentUser.value = null;
+}
+
+async function handleRoleSave(selectedRoleIds: number[]) {
+  if (!currentUser.value) return;
+
+  const userId = currentUser.value.id;
+  const originalRoleIds = new Set(currentUser.value.roles.map(r => r.id));
+  const newRoleIds = new Set(selectedRoleIds);
+
+  const rolesToAssign = selectedRoleIds.filter(id => !originalRoleIds.has(id));
+  const rolesToRemove = Array.from(originalRoleIds).filter(id => !newRoleIds.has(id));
+
+  try {
+    // Perform all API calls concurrently
+    await Promise.all([
+      ...rolesToAssign.map(roleId => api.assignRoleToUser(userId, roleId)),
+      ...rolesToRemove.map(roleId => api.removeRoleFromUser(userId, roleId))
+    ]);
+
+    alert(`نقش‌های کاربر ${currentUser.value.name} با موفقیت به‌روزرسانی شد.`);
+
+    // Update local data to reflect changes immediately
+    const updatedUser = users.value.find(u => u.id === userId);
+    if(updatedUser) {
+        updatedUser.roles = allRoles.value.filter(r => newRoleIds.has(r.id));
+    }
+
+  } catch (e) {
+    console.error('Failed to update user roles:', e);
+    alert('خطا در به‌روزرسانی نقش‌های کاربر.');
+  } finally {
+    closeModal();
+  }
+}
+</script>


### PR DESCRIPTION
- Creates a new page at `/admin/roles` for full CRUD management of roles and their associated permissions.
- Creates a new page at `/admin/users` for managing user roles.
- Adds reusable modal components for role and user-role editing.
- Updates the `useAuthApi` composable to include all necessary methods for interacting with the roles, permissions, and user-role assignment endpoints.

Note: The user management page currently uses placeholder data as the API endpoint for listing all users is not yet available. The implementation is ready to be connected to the live API once it's provided.