### PR TITLE
fix: Handle direct array response for roles list

### DIFF
--- a/app/pages/admin/roles.vue
+++ b/app/pages/admin/roles.vue
@@ -92,7 +92,8 @@ async function fetchRoles() {
     isLoading.value = true;
     // Fetch roles with their assigned permissions
     const response = await api.getRoles(true);
-    roles.value = response.data;
+    // Handle both wrapped and direct array responses
+    roles.value = Array.isArray(response.data) ? response.data : response;
   } catch (e) {
     error.value = e as Error;
     console.error("Failed to fetch roles:", e);


### PR DESCRIPTION
The roles management page was not displaying any roles because it strictly expected the API response to be an object with a `data` property (e.g., `{ "data": [...] }`).

This commit makes the data handling in `fetchRoles` more robust. It now correctly processes the roles list whether it is wrapped in a `data` property or returned as a direct array from the API (`[...]`).

This resolves the bug where the roles page appeared empty despite data existing in the database.