### PR TITLE
fix: Resolve admin users page errors and implement mock API

### DIFF
--- a/app/pages/admin/users.vue
+++ b/app/pages/admin/users.vue
@@ -110,16 +110,12 @@ async function fetchUsers() {
   error.value = null;
 
   try {
-    // We use useFetch to call our local mock API
-    const { data: response, error: fetchError } = await useFetch('/api/admin/users');
+    // Using $fetch as recommended for client-side calls after mount.
+    const response = await $fetch('/api/adminUsers');
 
-    if (fetchError.value) {
-      throw fetchError.value;
-    }
-
-    if (response.value && response.value.data) {
+    if (response && response.data) {
       // Assign roles to users based on the allRoles list
-      const usersData = response.value.data.map(user => ({
+      const usersData = response.data.map(user => ({
         ...user,
         roles: user.roles.map(role => allRoles.value.find(r => r.id === role.id)).filter(Boolean)
       }));

--- a/server/api/adminUsers.ts
+++ b/server/api/adminUsers.ts
@@ -1,4 +1,4 @@
-// server/api/admin/users.ts
+// server/api/adminUsers.ts
 // This is a mock API endpoint to simulate fetching users for the admin panel.
 // The real backend endpoint is not yet available.
 
@@ -64,9 +64,7 @@ export default defineEventHandler(async (event) => {
     },
   ];
 
-  // You can add query parameter handling here for pagination, filtering, etc.
-  // For now, we return the full list.
-
+  // This structure matches what the frontend component expects from the API response.
   return {
     data: mockUsers,
     meta: {


### PR DESCRIPTION
This commit resolves critical errors on the `/admin/users` page by implementing a robust mock API and fixing layout issues.

- Resolves the "Invalid layout `admin` selected" error by creating a new `app/layouts/admin.vue` file with a sidebar-based layout for the admin section.
- Resolves the "404 Not Found" error for the user list by creating a mock API endpoint at `server/api/adminUsers.ts`. This uses a flat file path to ensure it is correctly registered by the Nuxt server.
- Updates `app/pages/admin/users.vue` to fetch data from the new mock API endpoint using `$fetch`, as recommended by Nuxt for client-side data fetching.
- Deletes the redundant and confusing `app/pages/admin/users/index.vue` file to improve codebase clarity.

The admin users page now loads correctly with the proper layout and displays a functional list of mock users, unblocking further UI development.