### PR TITLE
fix: Correct the API path in the book debug page

### DIFF
--- a/app/pages/debug/book.vue
+++ b/app/pages/debug/book.vue
@@ -46,7 +46,7 @@ const fetchBook = async () => {
   try {
     // We need to get the raw response, so we can't use the processed one from useApi directly
     // Let's use $fetch directly for now to get the raw response
-    const response = await $fetch.raw('/api/v1/books/kelidar', {
+    const response = await $fetch.raw('/v1/books/kelidar', {
         baseURL: useRuntimeConfig().public.apiBase,
         headers: {
             'Accept': 'application/json',


### PR DESCRIPTION
This commit fixes a bug in the book debug page where the API URL was incorrect, causing a 404 error.

The duplicated "/api" prefix has been removed from the request path. This allows the debug page to correctly call the /api/v1/books/{slug} endpoint so that the actual backend response can be diagnosed.