### PR TITLE
fix: Correctly parse book data on the single book page

### DIFF
--- a/app/pages/books/[slug].vue
+++ b/app/pages/books/[slug].vue
@@ -75,10 +75,10 @@ const slug = route.params.slug
 const fetchBook = async () => {
   try {
     const response = await api.get(`/v1/books/${slug}`)
-    if (response && !response.error) {
-      book.value = response
+    if (response.success && response.data && response.data.book) {
+      book.value = response.data.book
       useHead({
-        title: response.title,
+        title: response.data.book.title,
       })
     } else {
       throw new Error(response.error || 'کتاب مورد نظر یافت نشد.')


### PR DESCRIPTION
This commit resolves the issue where the single book page was not displaying correctly.

The backend returns the book object nested within `response.data.book`, but the frontend component was trying to access it directly from the root of the response. This has been corrected.

This commit also includes the debug page (`/debug/book`) that was created to diagnose this issue.