### PR TITLE
refactor(auth): Use useApi for Sanctum CSRF cookie request

### DIFF
--- a/app/plugins/sanctum.client.ts
+++ b/app/plugins/sanctum.client.ts
@@ -1,10 +1,20 @@
+import { useApi } from '~/composables/useApi'
+
 export default defineNuxtPlugin(async () => {
+  // We don't need a token for the initial CSRF cookie request
+  const api = useApi()
+
   try {
-    await $fetch('/sanctum/csrf-cookie', {
-      credentials: 'include',
-    });
-    console.log('Sanctum CSRF cookie requested successfully.');
+    // We use the 'get' method from our useApi composable.
+    // This ensures that all necessary headers (like Accept: application/json)
+    // and options (like credentials: 'include') are automatically included.
+    // We override the baseURL because this specific endpoint is not under '/api'.
+    await api.get('/sanctum/csrf-cookie', {
+      baseURL: '/'
+    })
+    console.log('Sanctum CSRF cookie requested successfully via useApi.')
   } catch (error) {
-    console.error('Failed to fetch Sanctum CSRF cookie:', error);
+    // The error is already logged by the useApi composable, but we can log it here too if needed.
+    console.error('Plugin failed to fetch Sanctum CSRF cookie:', error)
   }
-});
+})


### PR DESCRIPTION
The initial request to `/sanctum/csrf-cookie` was failing with a 500 Internal Server Error. This was because the plain `$fetch` call in the `sanctum.client.ts` plugin was not sending the necessary `Accept: application/json` and `X-Requested-With: XMLHttpRequest` headers that the Laravel backend requires for API requests.

This commit refactors the `sanctum.client.ts` plugin to use the application's centralized `useApi` composable. This ensures the CSRF cookie request is sent with all the correct headers and options (`credentials: 'include'`), consistent with other API calls in the application.

This change is expected to resolve the 500 error, allowing the Sanctum session to be initialized correctly and fixing the downstream "Add to Cart" bug for both guest and authenticated users.