### PR TITLE
fix(cart): Gracefully handle 409 conflict on duplicate add

### DIFF
--- a/app/stores/cart.ts
+++ b/app/stores/cart.ts
@@ -50,11 +50,17 @@ export const useCartStore = defineStore('cart', {
     async addToCart(item: { product_id: number, product_type: string, price: number, quantity: number }) {
       const api = useApi()
       try {
-        const response = await api.post('/v1/cart/add', item)
-        await this.fetchCart()
-        return response
-      } catch (error) {
-        throw error
+        await api.post('/v1/cart/add', item)
+      } catch (error: any) {
+        // If the error is 409 Conflict, it means the item is already in the cart.
+        // This is not a real error for the user, so we can suppress it.
+        // For any other error, we let it propagate to the component.
+        if (error.response?.status !== 409) {
+          throw error;
+        }
+      } finally {
+        // No matter if it was a success or a 409 conflict, we want to sync the cart state.
+        await this.fetchCart();
       }
     },
 


### PR DESCRIPTION
This commit improves the robustness of the cart functionality.

The `addToCart` action in the `cart.ts` store has been updated to correctly handle the `409 Conflict` HTTP status code. When the backend returns a 409 error (indicating the item is already in the cart), the frontend will no longer treat it as an unhandled exception. Instead, it will suppress the error and proceed to re-fetch the cart state from the server.

This ensures that the UI remains in sync and correctly displays the "View Cart" link, even if the user attempts to add the same item multiple times.

Note: This does not fix the root backend issue causing a 500 error on `/sanctum/csrf-cookie`, which still needs to be addressed on the server-side.