### PR TITLE
fix(payment): Correct syntax in payment verification page

### DIFF
--- a/app/pages/payment/verify.vue
+++ b/app/pages/payment/verify.vue
@@ -62,7 +62,7 @@ onMounted(async () => {
     } else {
       throw new Error(response.message || 'خطا در تایید پرداخت در سرور.')
     }
-  } catch (err: any) {
+  } catch (err) {
     status.value = 'failure'
     errorMessage.value = err.response?._data?.message || err.message || 'یک خطای پیش‌بینی نشده رخ داد.'
   }


### PR DESCRIPTION
This commit fixes a Vue/Vite compilation error in the `verify.vue` page.

The error `[vue/compiler-sfc] Unexpected token, expected ")"` was caused by using TypeScript syntax (`catch (err: any)`) in a standard JavaScript `<script setup>` block.

The fix changes the statement to the correct JavaScript syntax: `catch (err)`. This resolves the compilation error and allows the application to build successfully.