### PR TITLE
fix: Standardize API URL construction and refactor auth logic

### DIFF
--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -5,39 +5,49 @@ import type { FetchOptions } from 'ofetch'
 export const useApi = (token: string | null = null) => {
   const config = useRuntimeConfig()
 
-  // Centralized fetch function
   const fetchApi = (url: string, options: FetchOptions) => {
-    console.log('--- [useApi] Initiating new API call ---')
-    console.log(`[useApi] Received URL: ${url}`)
+    let baseURL = ''
+    let path = url
 
-    // Log environment and config variables
-    console.log(`[useApi] process.dev: ${process.dev}`)
-    console.log(`[useApi] config.public.apiBase: ${config.public.apiBase}`)
-
-    // Determine the correct baseURL
-    const baseURL = process.dev ? '/api/v1' : config.public.apiBase
-    console.log(`[useApi] Calculated baseURL: ${baseURL}`)
-
-    // Special case for Sanctum CSRF cookie
-    if (url === '/sanctum/csrf-cookie') {
-      console.log('[useApi] Handling special case for /sanctum/csrf-cookie')
-      const sanctumBaseURL = process.dev ? '' : config.public.apiBase
-      console.log(`[useApi] Sanctum baseURL: ${sanctumBaseURL}`)
-      return $fetch(url, {
-        ...options,
-        baseURL: sanctumBaseURL,
-        onRequest({ request, options }) {
-          console.log('[useApi] Final $fetch request details (Sanctum):', { url: request.toString(), options })
-        }
-      })
+    // Step 1: Construct the full path with the correct version prefix.
+    // This ensures that calls like `api.get('/users')` become `api.get('/api/v1/users')`.
+    if (!path.startsWith('/api/v1') && !path.startsWith('/sanctum')) {
+      path = `/api/v1${path}`
     }
 
-    return $fetch(url, {
-      ...options,
-      baseURL,
-      onRequest({ request, options }) {
-        console.log('[useApi] Final $fetch request details:', { url: request.toString(), options })
+    // Step 2: Determine the base URL (domain only).
+    if (process.dev) {
+      // In development mode, the baseURL is empty.
+      // The full path (e.g., /api/v1/users) will be called relative to the current domain,
+      // which is correctly handled by the Nuxt dev server proxy.
+      baseURL = ''
+    } else {
+      // In production mode, we need to use the configured API base.
+      // We extract only the origin (e.g., http://localhost:8000) from the user's
+      // configured NUXT_PUBLIC_API_BASE to avoid issues with extra path segments.
+      try {
+        const configuredUrl = new URL(config.public.apiBase)
+        baseURL = configuredUrl.origin
+      } catch (e) {
+        console.error(
+          "Invalid NUXT_PUBLIC_API_BASE URL in config. It should be a full URL like 'http://your-api.com'. Falling back to a relative path.",
+          e
+        )
+        // Fallback to a safe relative path if the URL is misconfigured.
+        baseURL = ''
       }
+    }
+
+    // Step 3: Handle the Sanctum CSRF cookie route as a special case.
+    // It should not be prefixed with /api/v1.
+    if (url === '/sanctum/csrf-cookie') {
+      path = url // Reset path to not include /api/v1
+    }
+
+    // Step 4: Make the request using the constructed path and baseURL.
+    return $fetch(path, {
+      ...options,
+      baseURL
     })
   }
 
@@ -57,44 +67,12 @@ export const useApi = (token: string | null = null) => {
     return headers
   }
 
+  // Return the API methods
   return {
-    get: (url: string, options: FetchOptions = {}) => {
-      return fetchApi(url, {
-        ...options,
-        method: 'GET',
-        headers: createHeaders(false),
-      })
-    },
-    post: (url: string, body: any = {}, options: FetchOptions = {}) => {
-      return fetchApi(url, {
-        ...options,
-        method: 'POST',
-        body,
-        headers: createHeaders(true),
-      })
-    },
-    put: (url: string, body: any = {}, options: FetchOptions = {}) => {
-      return fetchApi(url, {
-        ...options,
-        method: 'PUT',
-        body,
-        headers: createHeaders(true),
-      })
-    },
-    patch: (url: string, body: any = {}, options: FetchOptions = {}) => {
-      return fetchApi(url, {
-        ...options,
-        method: 'PATCH',
-        body,
-        headers: true,
-      })
-    },
-    delete: (url: string, options: FetchOptions = {}) => {
-      return fetchApi(url, {
-        ...options,
-        method: 'DELETE',
-        headers: createHeaders(false),
-      })
-    },
+    get: (url: string, options: FetchOptions = {}) => fetchApi(url, { ...options, method: 'GET', headers: createHeaders(false) }),
+    post: (url: string, body: any = {}, options: FetchOptions = {}) => fetchApi(url, { ...options, method: 'POST', body, headers: createHeaders(true) }),
+    put: (url: string, body: any = {}, options: FetchOptions = {}) => fetchApi(url, { ...options, method: 'PUT', body, headers: createHeaders(true) }),
+    patch: (url: string, body: any = {}, options: FetchOptions = {}) => fetchApi(url, { ...options, method: 'PATCH', body, headers: createHeaders(true) }),
+    delete: (url: string, options: FetchOptions = {}) => fetchApi(url, { ...options, method: 'DELETE', headers: createHeaders(false) }),
   }
 }

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -158,12 +158,12 @@ export const useAuthStore = defineStore('auth', {
 
     async getProvinces() {
       const api = useApi()
-      return await api.get('/provinces')
+      return await api.get('/locations/provinces')
     },
 
     async getCities(provinceId: number) {
       const api = useApi()
-      return await api.get(`/provinces/${provinceId}/cities`)
+      return await api.get(`/locations/provinces/${provinceId}/cities`)
     },
 
     async sendEmailVerification(email: string) {


### PR DESCRIPTION
This commit provides a robust and permanent fix for the inconsistent API URL prefix issue. It refactors the core API handling to ensure all requests are correctly versioned and centralizes all authentication and profile management logic into a single Pinia store.

- The `useApi.ts` composable now intelligently constructs the full API path, prepending `/api/v1` and handling different environments (dev/prod) and configurations robustly.
- All authentication and profile-related API actions are now centralized in the `auth.ts` store, including login flows, profile updates, and location fetching.
- The `auth.vue` and `profile.vue` pages have been refactored to be driven entirely by the `auth` store, separating UI from business logic.
- Corrected a regression where profile functionality was lost and fixed incorrect URL paths for location data.