### PR TITLE
fix(auth): Implement logout functionality in auth store

### DIFF
--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -75,6 +75,17 @@ export const useAuthStore = defineStore('auth', {
       return response;
     },
 
+    async logout() {
+      const api = useApi(this.token);
+      try {
+        await api.post('/auth/logout');
+      } catch (error) {
+        console.error('Logout failed, but clearing auth state anyway.', error);
+      } finally {
+        this.clearAuth();
+      }
+    },
+
     setAuth(data: any) {
       // ... (rest of the existing setAuth function)
       let payload: any = data


### PR DESCRIPTION
This commit adds the `logout` action to the `auth` Pinia store to fix the broken logout functionality.

- The new `logout` action makes a POST request to the `/auth/logout` endpoint.
- It correctly uses the existing `useApi` composable, ensuring the correct base URL is prefixed.
- It calls the `clearAuth` action in a `finally` block to ensure the user's session state and local storage are cleared, even if the API call fails.

This change restores the logout functionality which was previously broken due to the missing action in the store.