### PR TITLE
fix: Correct useApi composable usage and finalize refactor

### DIFF
--- a/app/pages/books/[slug].vue
+++ b/app/pages/books/[slug].vue
@@ -78,7 +78,7 @@ useHead({
 })
 
 const route = useRoute()
-const { $api } = useApi()
+const api = useApi() // Corrected: instantiate the whole composable object
 
 const book = ref(null)
 const loading = ref(true)
@@ -94,7 +94,7 @@ const purchaseInProgress = ref(false)
 
 const fetchBook = async () => {
   try {
-    const response = await $api.get(`/books/${slug}`)
+    const response = await api.get(`/books/${slug}`) // Corrected: use api.get
     book.value = response
     useHead({
       title: response.title,
@@ -116,7 +116,7 @@ const validateCoupon = async () => {
   validatingCoupon.value = true
   couponMessage.value = ''
   try {
-    const response = await $api.post('/purchase/coupon/validate', { code: couponCode.value })
+    const response = await api.post('/purchase/coupon/validate', { code: couponCode.value }) // Corrected: use api.post
     if (response.success) {
       couponMessage.value = `کد تخفیف معتبر است: ${response.data.percentage}%`
       couponMessageClass.value = 'text-green-600'
@@ -133,15 +133,13 @@ const handlePurchase = async () => {
   if (!book.value) return;
   purchaseInProgress.value = true
   try {
-    const response = await $api.post(`/books/${book.value.id}/buy`, {
+    const response = await api.post(`/books/${book.value.id}/buy`, { // Corrected: use api.post
       payment_method: 'zarinpal',
       coupon_code: couponCode.value || null,
     })
     if (response.success && response.data.payment_url) {
-      // Redirect user to the payment gateway
       await navigateTo(response.data.payment_url, { external: true })
     } else {
-      // Handle cases where payment URL is not returned
       alert('خطا در ایجاد لینک پرداخت. لطفاً دوباره تلاش کنید.')
     }
   } catch (err) {


### PR DESCRIPTION
This commit fixes a critical TypeError (`$api.get is not a function`) that occurred after the initial refactoring of the `useApi` composable. The error was caused by incorrect destructuring of the composable's return value in multiple components.

This commit addresses the issue by:
1.  Correcting the instantiation of `useApi` in all affected files from `const { $api } = useApi()` to `const api = useApi()`.
2.  Updating all API calls to use the correct `api.get()`, `api.post()`, etc. methods.
3.  Enhancing the `useApi` composable to include `put` and `delete` methods for full RESTful support.
4.  Creating several new placeholder API routes that were required by the refactored components but were missed in the previous step.

This commit also finalizes the two major refactoring tasks:
- Standardizing the API structure under `/server/api/v1/`.
- Replacing the shopping cart with a direct purchase flow.

All components, stores, and pages have been updated, and the application now builds successfully without errors.