### PR TITLE
fix(admin): correct API endpoints for dashboard and users

### DIFF
--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -116,7 +116,7 @@ const addError = (error) => {
 
 const loadStats = async () => {
   try {
-    const response = await api.get('/dashboard')
+    const response = await api.get('/dashboard/stats')
     stats.value = response.data || response
   } catch (error) {
     console.error('Error fetching stats:', error)

--- a/app/pages/admin/users/index.vue
+++ b/app/pages/admin/users/index.vue
@@ -262,7 +262,7 @@ const loadUsers = async (page = 1) => {
       }
     })
     // The old API used `/auth/users`. The new structure is `/users`.
-    const response = await api.get('/users', { params })
+    const response = await api.get('/auth/users', { params })
     if (response.data && response.meta) {
       users.value = response.data
       pagination.value = response.meta
@@ -280,7 +280,7 @@ const loadUsers = async (page = 1) => {
 
 const toggleUserLock = async (user) => {
   try {
-    await api.post(`/users/${user.id}/toggle-lock`)
+    await api.post(`/auth/users/${user.id}/toggle-lock`)
     await loadUsers(pagination.value.current_page)
     alert('Operation successful')
   } catch (err) {
@@ -294,7 +294,7 @@ const resetUserPassword = async (user) => {
   if (!newPassword) return
 
   try {
-    await api.post(`/users/${user.id}/reset-password`, {
+    await api.post(`/auth/users/${user.id}/reset-password`, {
       password: newPassword,
       password_confirmation: newPassword
     })


### PR DESCRIPTION
Corrects the API endpoints used in the admin panel to resolve 404 Not Found errors.
- Changes the dashboard stats endpoint from `/dashboard` to `/dashboard/stats` in `app/pages/admin/index.vue`.
- Prefixes all user management endpoints (`/users`, `/users/{id}/toggle-lock`, `/users/{id}/reset-password`) with `/auth` in `app/pages/admin/users/index.vue` to align with the API documentation.