### PR TITLE
feat: Separate public and authenticated API clients

### DIFF
--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -95,7 +95,7 @@
 </template>
 
 <script setup>
-import { useApi } from '~/composables/useApi'
+import { useApiAuth } from '~/composables/useApiAuth'
 import { useAuthStore } from '~/stores/auth'
 import { useRuntimeConfig } from '#app'
 
@@ -105,7 +105,7 @@ definePageMeta({
 })
 
 const authStore = useAuthStore()
-const api = useApi()
+const api = useApiAuth()
 
 const stats = ref({})
 const errors = ref([])

--- a/app/pages/admin/users/index.vue
+++ b/app/pages/admin/users/index.vue
@@ -206,7 +206,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import { useApi } from '~/composables/useApi'
+import { useApiAuth } from '~/composables/useApiAuth'
 import { useAuthStore } from '~/stores/auth'
 
 definePageMeta({
@@ -215,7 +215,7 @@ definePageMeta({
 })
 
 const authStore = useAuthStore()
-const api = useApi()
+const api = useApiAuth()
 
 const users = ref([])
 const loading = ref(false)

--- a/app/pages/books/[slug].vue
+++ b/app/pages/books/[slug].vue
@@ -74,13 +74,15 @@
 import { ref, onMounted, computed } from 'vue'
 import { useRoute, navigateTo } from '#app'
 import { useApi } from '~/composables/useApi'
+import { useApiAuth } from '~/composables/useApiAuth'
 
 useHead({
   title: 'جزئیات کتاب',
 })
 
 const route = useRoute()
-const api = useApi() // Corrected: instantiate the whole composable object
+const api = useApi() // Public client
+const apiAuth = useApiAuth() // Authenticated client
 
 const book = ref(null)
 const loading = ref(true)
@@ -123,7 +125,7 @@ const validateCoupon = async () => {
   validatingCoupon.value = true
   couponMessage.value = ''
   try {
-    const response = await api.post('/purchase/coupon/validate', { code: couponCode.value }) // Corrected: use api.post
+    const response = await apiAuth.post('/purchase/coupon/validate', { code: couponCode.value })
     if (response.success) {
       couponMessage.value = `کد تخفیف معتبر است: ${response.data.percentage}%`
       couponMessageClass.value = 'text-green-600'
@@ -140,7 +142,7 @@ const handlePurchase = async () => {
   if (!book.value) return;
   purchaseInProgress.value = true
   try {
-    const response = await api.post(`/books/${book.value.id}/buy`, { // Corrected: use api.post
+    const response = await apiAuth.post(`/books/${book.value.id}/buy`, {
       payment_method: 'zarinpal',
       coupon_code: couponCode.value || null,
     })

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -663,7 +663,8 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useAuthStore } from '~/stores/auth'
-import { useApi } from '~/composables/useApi' // Replaced useProfile with useApi
+import { useApi } from '~/composables/useApi'
+import { useApiAuth } from '~/composables/useApiAuth'
 import { useFormatters } from '~/composables/useFormatters'
 
 definePageMeta({
@@ -673,7 +674,8 @@ definePageMeta({
 
 // Store and API
 const authStore = useAuthStore()
-const api = useApi() // Use the main API composable
+const api = useApi() // Public API client
+const apiAuth = useApiAuth() // Authenticated API client
 const formatters = useFormatters()
 
 // Use the user from the store as the single source of truth
@@ -885,12 +887,12 @@ const handlePassword = async () => {
   }
 }
 
-// These methods can remain similar, just ensuring they use the main `api` composable
+// These methods now use the authenticated `apiAuth` client
 const handleEmailVerification = async () => {
   if (!form.value.email) return
   emailVerificationSending.value = true
   try {
-    await api.post('/email/send-verification', { email: form.value.email })
+    await apiAuth.post('/email/send-verification', { email: form.value.email })
     verificationModal.value = { type: 'email', target: form.value.email }
     showVerificationModal.value = true
   } catch (error) {
@@ -904,7 +906,7 @@ const handlePhoneVerification = async () => {
   if (!form.value.phone) return
   smsVerificationSending.value = true
   try {
-    await api.post('/phone/send-verification', { phone: form.value.phone })
+    await apiAuth.post('/phone/send-verification', { phone: form.value.phone })
     verificationModal.value = { type: 'phone', target: form.value.phone }
     showVerificationModal.value = true
   } catch (error) {
@@ -920,10 +922,10 @@ const verifyCode = async () => {
   try {
     let response;
     if (verificationModal.value.type === 'email') {
-      response = await api.post('/email/verify', { email: verificationModal.value.target, otp: verificationCode.value })
+      response = await apiAuth.post('/email/verify', { email: verificationModal.value.target, otp: verificationCode.value })
       showMessage('ایمیل با موفقیت تایید شد', 'success')
     } else {
-      response = await api.post('/phone/verify', { phone: verificationModal.value.target, otp: verificationCode.value })
+      response = await apiAuth.post('/phone/verify', { phone: verificationModal.value.target, otp: verificationCode.value })
       showMessage('شماره موبایل با موفقیت تایید شد', 'success')
     }
     if (response) {

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { useApi } from '~/composables/useApi'
+import { useApiAuth } from '~/composables/useApiAuth'
 
 interface User {
   id: number
@@ -44,24 +44,24 @@ export const useAuthStore = defineStore('auth', {
 
   actions: {
     async checkUser(identifier: string) {
-      const api = useApi();
+      const api = useApiAuth();
       return await api.post('/auth/check-user', { identifier });
     },
 
     async loginWithPassword(identifier: string, password: string) {
-      const api = useApi();
+      const api = useApiAuth();
       const response = await api.post('/auth/login-password', { identifier, password });
       this.setAuth(response);
       return response;
     },
 
     async sendOtp(identifier: string) {
-      const api = useApi();
+      const api = useApiAuth();
       return await api.post('/auth/send-otp', { identifier });
     },
 
     async verifyOtp(identifier: string, otp: string, name?: string) {
-      const api = useApi();
+      const api = useApiAuth();
       const payload: { identifier: string; otp: string; name?: string } = { identifier, otp };
       if (name) {
         payload.name = name;
@@ -72,7 +72,7 @@ export const useAuthStore = defineStore('auth', {
     },
 
     async logout() {
-      const api = useApi();
+      const api = useApiAuth();
       try {
         await api.post('/auth/logout');
       } catch (error) {
@@ -83,7 +83,7 @@ export const useAuthStore = defineStore('auth', {
     },
 
     async logoutAll() {
-      const api = useApi();
+      const api = useApiAuth();
       try {
         await api.post('/auth/logout-all');
       } catch (error) {
@@ -94,7 +94,7 @@ export const useAuthStore = defineStore('auth', {
     },
 
     async updateProfile(data: any) {
-      const api = useApi();
+      const api = useApiAuth();
       const response = await api.post('/auth/profile/update', data);
       if (response.user) {
         this.setUser(response.user);
@@ -103,18 +103,18 @@ export const useAuthStore = defineStore('auth', {
     },
 
     async setPassword(password: string, password_confirmation: string) {
-      const api = useApi();
+      const api = useApiAuth();
       return await api.post('/auth/password/set', { password, password_confirmation });
     },
 
     async updatePassword(current_password: string, password: string, password_confirmation: string) {
-      const api = useApi();
+      const api = useApiAuth();
       return await api.post('/auth/password/update', { current_password, password, password_confirmation });
     },
 
     async refreshToken() {
       if (!this.refreshToken) return;
-      const api = useApi();
+      const api = useApiAuth();
       try {
         const response = await api.post('/auth/refresh', { refresh_token: this.refreshToken });
         this.setAuth(response);
@@ -170,7 +170,7 @@ export const useAuthStore = defineStore('auth', {
       if (!this.token) {
         return null
       }
-      const api = useApi()
+      const api = useApiAuth()
       try {
         const response = await api.get('/auth/user')
         this.user = (response && typeof response === 'object') ? (response.user || response) : null


### PR DESCRIPTION
This commit refactors the API handling layer to introduce two distinct composables: `useApi` for public requests and `useApiAuth` for authenticated requests.

- `useApiAuth` is the new name for the composable that automatically attaches the `Authorization` header.
- `useApi` is now a simple, public client that does not send authentication details.
- All protected pages and actions (auth store, admin pages, profile page actions) have been updated to use `useApiAuth`.
- Public pages (like the single book page) have been updated to use the public `useApi` for fetching data, while still using `useApiAuth` for actions that require a logged-in user (like purchasing).

This resolves the 500 error on public pages caused by sending an unexpected auth header and creates a more robust and maintainable API communication strategy for the application.