### PR TITLE
fix: Use book slug for purchase API call

### DIFF
--- a/app/pages/books/[slug].vue
+++ b/app/pages/books/[slug].vue
@@ -140,7 +140,7 @@ const handleBuyClick = async () => {
     // Authenticated user logic
     purchaseInProgress.value = true
     try {
-      const response = await apiAuth.post(`/books/${book.value.id}/buy`)
+      const response = await apiAuth.post(`/books/${book.value.slug}/buy`)
 
       // As per docs, a 200 OK is success
       purchaseMessage.value = response.message || 'خرید شما با موفقیت انجام شد.'


### PR DESCRIPTION
This commit fixes a bug in the book purchase flow where a `ModelNotFoundException` was being returned from the backend.

The issue was caused by sending the book's numeric ID to the `/api/v1/books/{identifier}/buy` endpoint, whereas the backend route expects the book's string slug. This was confirmed by the user's successful `cURL` test using the slug.

This patch corrects the API call in `app/pages/books/[slug].vue` to send `book.slug` instead of `book.id`, aligning the frontend with the backend's expectation and resolving the error.