### PR TITLE
Fix(purchase): Use book slug for purchase API call

### DIFF
--- a/app/pages/books/[slug].vue
+++ b/app/pages/books/[slug].vue
@@ -142,7 +142,7 @@ const handlePurchase = async () => {
   if (!book.value) return;
   purchaseInProgress.value = true
   try {
-    const response = await apiAuth.post(`/books/${book.value.id}/buy`, {
+    const response = await apiAuth.post(`/books/${slug}/buy`, {
       payment_method: 'zarinpal',
       coupon_code: couponCode.value || null,
     })


### PR DESCRIPTION
The book purchase API call was incorrectly using the book's ID instead of its slug, causing a 'No query results' error on the backend.

This change modifies the `handlePurchase` function in `app/pages/books/[slug].vue` to use the `slug` variable, which is available from the route parameters. This aligns the frontend implementation with the API documentation and resolves the bug.