### PR TITLE
feat: Add 'My Books' page and prevent duplicate purchases

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -46,6 +46,11 @@
                         class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                 پروفایل
               </NuxtLink>
+              <NuxtLink to="/my-books"
+                        @click="showUserMenu = false"
+                        class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                کتاب‌های من
+              </NuxtLink>
 
               <!-- Admin Menu -->
               <div v-if="authStore.isAdmin">

--- a/app/pages/books/[slug].vue
+++ b/app/pages/books/[slug].vue
@@ -34,9 +34,9 @@
           <!-- Purchased State -->
           <div v-if="book.is_purchased" class="text-center">
             <p class="font-semibold text-lg text-green-600">شما این کتاب را خریداری کرده‌اید.</p>
-            <button class="mt-2 bg-green-500 text-white font-bold py-2 px-6 rounded-lg hover:bg-green-600">
-              مشاهده کتاب
-            </button>
+            <NuxtLink to="/my-books" class="mt-2 inline-block bg-green-500 text-white font-bold py-2 px-6 rounded-lg hover:bg-green-600 transition">
+              مشاهده در کتابخانه
+            </NuxtLink>
           </div>
 
           <!-- Direct Purchase Flow -->

--- a/app/pages/my-books.vue
+++ b/app/pages/my-books.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="container mx-auto p-4 md:p-8">
+    <h1 class="text-3xl font-bold text-gray-800 mb-6">کتاب‌های من</h1>
+
+    <div v-if="loading" class="text-center">
+      <p>در حال بارگذاری کتابخانه شما...</p>
+    </div>
+
+    <div v-else-if="error" class="text-center text-red-500">
+      <p>خطا در دریافت اطلاعات: {{ error.message }}</p>
+    </div>
+
+    <div v-else-if="purchases && purchases.length > 0" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      <div v-for="purchase in purchases" :key="purchase.purchase_id" class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:scale-105">
+        <img :src="purchase.book.cover_image_url" :alt="purchase.book.title" class="w-full h-64 object-cover">
+        <div class="p-4">
+          <h2 class="text-lg font-semibold text-gray-800">{{ purchase.book.title }}</h2>
+          <p class="text-sm text-gray-600 mb-4">خریداری شده</p>
+          <a :href="`/api/v1/downloads/${purchase.download_token}`"
+             class="w-full text-center block bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition">
+            دانلود
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div v-else class="text-center text-gray-500">
+      <p>شما هنوز هیچ کتابی خریداری نکرده‌اید.</p>
+      <NuxtLink to="/" class="mt-4 inline-block text-blue-600 hover:underline">مشاهده فروشگاه</NuxtLink>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useApiAuth } from '~/composables/useApiAuth'
+
+// Page metadata, including protecting the route with auth middleware
+definePageMeta({
+  middleware: 'auth'
+})
+
+useHead({
+  title: 'کتاب‌های من'
+})
+
+const apiAuth = useApiAuth()
+const purchases = ref([])
+const loading = ref(true)
+const error = ref(null)
+
+const fetchMyPurchases = async () => {
+  try {
+    const response = await apiAuth.get('/books/my-purchases')
+    if (response.success) {
+      purchases.value = response.data
+    } else {
+      throw new Error('Failed to fetch purchased books.')
+    }
+  } catch (err) {
+    console.error('Failed to fetch purchases:', err)
+    error.value = err.data || err
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchMyPurchases)
+</script>

--- a/server/api/v1/books/[slug].get.ts
+++ b/server/api/v1/books/[slug].get.ts
@@ -1,6 +1,14 @@
+import { db } from '~/server/utils/db'
+
 export default defineEventHandler((event) => {
   const slug = getRouterParam(event, 'slug')
+  const user = event.context.auth?.user
 
+  // Determine if the book is purchased by the current user.
+  // If there is no user, it's considered not purchased for this session.
+  const isPurchased = user ? db.hasPurchased(user.id, slug) : false
+
+  // Mock book data - in a real app, this would be fetched from a database.
   const book = {
     id: 1,
     slug: slug,
@@ -14,7 +22,7 @@ export default defineEventHandler((event) => {
     isbn: '978-1234567890',
     price: 50000,
     sale_price: 45000,
-    is_purchased: false,
+    is_purchased: isPurchased, // The dynamically set value
     image: {
       url: 'https://via.placeholder.com/400x600',
       thumbnail_url: 'https://via.placeholder.com/150x225'

--- a/server/api/v1/books/[slug]/buy.post.ts
+++ b/server/api/v1/books/[slug]/buy.post.ts
@@ -1,13 +1,5 @@
 import { H3Event } from 'h3'
-
-// Mock function to simulate creating an order in the database
-const createOrder = async (bookSlug: string, userId: string | number) => {
-  console.log(`Creating order for book '${bookSlug}' for user '${userId}'...`)
-  // In a real application, you would save this to the database
-  const mockOrderId = Math.floor(Math.random() * 90000) + 10000
-  console.log(`Order created with ID: ${mockOrderId}`)
-  return { order_id: mockOrderId }
-}
+import { db } from '~/server/utils/db'
 
 export default defineEventHandler(async (event: H3Event) => {
   // Step 1: Get the book slug from the URL
@@ -19,41 +11,38 @@ export default defineEventHandler(async (event: H3Event) => {
     })
   }
 
-  // Step 2: Ensure the user is authenticated.
-  // The 'auth' middleware in Nuxt should have already handled this.
-  // We can access the user from the event context if the middleware adds it.
-  // Example: const user = event.context.auth?.user
-  // For this mock, we'll assume the user is authenticated if the call reaches here.
-  // In a real app, you'd have proper user validation.
+  // Step 2: Ensure the user is authenticated
   const user = event.context.auth?.user
   if (!user) {
     throw createError({
       statusCode: 401,
-      statusMessage: 'Unauthorized',
+      statusMessage: 'Unauthorized. Please log in to purchase.',
     })
   }
 
+  // Step 3: Check if the book has already been purchased
+  if (db.hasPurchased(user.id, slug)) {
+    throw createError({
+      statusCode: 409, // Conflict
+      statusMessage: 'شما قبلاً این کتاب را خریداری کرده‌اید.',
+    })
+  }
 
   try {
-    // Step 3: Process the direct purchase.
-    // No request body is needed for this operation.
-    const orderData = await createOrder(slug, user.id)
+    // Step 4: Process the direct purchase by adding it to our mock DB
+    const newPurchase = db.addPurchase(user.id, slug)
 
-    // Step 4: Return the success response as per the documentation.
+    // Step 5: Return the success response
     return {
       success: true,
       message: 'خرید شما با موفقیت انجام شد.',
       data: {
-        order_id: orderData.order_id,
+        order_id: newPurchase.purchaseId,
       },
     }
   } catch (error: any) {
-    // Step 5: Handle potential errors.
+    // Step 6: Handle any other unexpected errors
     console.error(`Error processing purchase for book '${slug}':`, error)
-
-    // This could be a 404 if the book slug is not found,
-    // or a 409 if the book is already purchased.
-    // For now, we return a generic server error.
     throw createError({
       statusCode: 500,
       message: 'خطا در پردازش خرید شما. لطفاً دوباره تلاش کنید.',

--- a/server/api/v1/books/my-purchases.get.ts
+++ b/server/api/v1/books/my-purchases.get.ts
@@ -1,0 +1,42 @@
+import { H3Event } from 'h3'
+import { db } from '~/server/utils/db'
+
+// Mock function to get book details. In a real app, this would query a database.
+const getBookDetails = (slug: string) => {
+    return {
+        title: `کتاب ${slug}`,
+        slug: slug,
+        cover_image_url: 'https://via.placeholder.com/150x225'
+    };
+};
+
+export default defineEventHandler(async (event: H3Event) => {
+  const user = event.context.auth?.user;
+
+  if (!user) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Unauthorized. Please log in to see your purchases.',
+    });
+  }
+
+  const userPurchases = db.getUserPurchases(user.id);
+
+  const responseData = userPurchases.map(purchase => {
+    // Add a mock expiration date, e.g., one year from now.
+    const expiresAt = new Date();
+    expiresAt.setFullYear(expiresAt.getFullYear() + 1);
+
+    return {
+      purchase_id: purchase.purchaseId,
+      book: getBookDetails(purchase.bookSlug),
+      download_token: purchase.downloadToken,
+      expires_at: expiresAt.toISOString(),
+    };
+  });
+
+  return {
+    success: true,
+    data: responseData,
+  };
+});

--- a/server/api/v1/downloads/[token].get.ts
+++ b/server/api/v1/downloads/[token].get.ts
@@ -1,0 +1,38 @@
+import { H3Event } from 'h3'
+import { db } from '~/server/utils/db'
+
+export default defineEventHandler(async (event: H3Event) => {
+  const token = getRouterParam(event, 'token');
+
+  if (!token) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Download token is required.',
+    });
+  }
+
+  // Validate the token against our mock database
+  const purchase = db.findPurchaseByToken(token);
+
+  if (!purchase) {
+    throw createError({
+      statusCode: 404, // Using 404 to not reveal the existence of a token
+      statusMessage: 'Invalid or expired download link.',
+    });
+  }
+
+  // --- Simulate File Download ---
+  // In a real application, you would fetch a file from storage (e.g., S3)
+  // and stream it back to the user.
+
+  // 1. Set the appropriate headers for a file download.
+  const bookFileName = `${purchase.bookSlug}.epub`; // Example file name
+  setResponseHeaders(event, {
+    'Content-Type': 'application/epub+zip', // Example MIME type for an e-book
+    'Content-Disposition': `attachment; filename="${bookFileName}"`,
+  });
+
+  // 2. Return the file content.
+  // For this mock, we'll just return a simple string as the file content.
+  return `This is the content of the mock e-book "${purchase.bookSlug}". Happy reading!`;
+});

--- a/server/utils/db.ts
+++ b/server/utils/db.ts
@@ -1,0 +1,102 @@
+// A mock in-memory database to simulate storing user purchases and book data.
+
+// --- Interfaces ---
+interface Purchase {
+  userId: string | number;
+  bookSlug: string;
+  purchaseId: number;
+  downloadToken: string;
+}
+
+interface Book {
+  slug: string;
+  title: string;
+  // ... other book properties
+}
+
+
+// --- In-memory Data Store ---
+// Using a Map for efficient lookups. Key: userId, Value: Map<bookSlug, Purchase>
+const purchases = new Map<string | number, Map<string, Purchase>>();
+
+
+// --- Mock Data Initialization ---
+// Pre-populate with some data for a default user (e.g., user with id 1) for testing.
+const initialUserPurchases = new Map<string, Purchase>();
+initialUserPurchases.set('savushun', {
+    userId: 1,
+    bookSlug: 'savushun',
+    purchaseId: 101,
+    downloadToken: 'unique_download_token_for_user_1_and_book_savushun'
+});
+purchases.set(1, initialUserPurchases);
+
+
+// --- Database Interaction Logic ---
+export const db = {
+  /**
+   * Checks if a user has purchased a specific book.
+   * @param userId - The ID of the user.
+   * @param bookSlug - The slug of the book.
+   * @returns True if the book has been purchased, false otherwise.
+   */
+  hasPurchased: (userId: string | number, bookSlug: string): boolean => {
+    return purchases.get(userId)?.has(bookSlug) ?? false;
+  },
+
+  /**
+   * Adds a new purchase record for a user.
+   * @param userId - The ID of the user.
+   * @param bookSlug - The slug of the book being purchased.
+   * @returns The newly created purchase record.
+   */
+  addPurchase: (userId: string | number, bookSlug: string): Purchase => {
+    if (!purchases.has(userId)) {
+      purchases.set(userId, new Map<string, Purchase>());
+    }
+
+    const userPurchases = purchases.get(userId)!;
+
+    // This check should be done before calling addPurchase, but it's a safeguard.
+    if (userPurchases.has(bookSlug)) {
+        return userPurchases.get(bookSlug)!;
+    }
+
+    const newPurchase: Purchase = {
+      userId,
+      bookSlug,
+      purchaseId: Math.floor(Math.random() * 90000) + 10000,
+      downloadToken: `token_${userId}_${bookSlug}_${Date.now()}`
+    };
+
+    userPurchases.set(bookSlug, newPurchase);
+    console.log(`[DB MOCK] New purchase added for user ${userId}, book ${bookSlug}`);
+    return newPurchase;
+  },
+
+  /**
+   * Gets all purchases for a specific user.
+   * @param userId - The ID of the user.
+   * @returns An array of purchase records.
+   */
+  getUserPurchases: (userId: string | number): Purchase[] => {
+    const userPurchasesMap = purchases.get(userId);
+    return userPurchasesMap ? Array.from(userPurchasesMap.values()) : [];
+  },
+
+  /**
+   * Finds a purchase record by its unique download token.
+   * @param token - The download token.
+   * @returns The purchase record if found, otherwise undefined.
+   */
+  findPurchaseByToken: (token: string): Purchase | undefined => {
+      for (const userPurchases of purchases.values()) {
+          for (const purchase of userPurchases.values()) {
+              if (purchase.downloadToken === token) {
+                  return purchase;
+              }
+          }
+      }
+      return undefined;
+  }
+};


### PR DESCRIPTION
This commit introduces a new 'My Books' feature and fixes a critical bug that allowed users to purchase the same book multiple times.

Backend:
- The `POST /api/v1/books/{slug}/buy` endpoint now checks if the user has already purchased the book and returns a 409 Conflict error if true.
- The `GET /api/v1/books/{slug}` endpoint now includes a dynamic `is_purchased` boolean to reflect the user's ownership status.
- A new `GET /api/v1/books/my-purchases` endpoint is created to return a list of all books purchased by the authenticated user.
- A new `GET /api/v1/downloads/{token}` endpoint is created to handle secure file downloads.
- A mock in-memory database (`server/utils/db.ts`) has been added to support this functionality.

Frontend:
- A new 'My Books' page (`/my-books`) is created to display the user's library of purchased books with download links.
- The book details page (`/books/{slug}`) now uses the `is_purchased` flag to change the buy button into a 'View in Library' link for owned books.
- A navigation link to the 'My Books' page has been added to the user dropdown menu in the main layout.