### PR TITLE
fix: Resolve server crash by removing incorrect imports

### DIFF
--- a/server/api/v1/books/[slug].get.ts
+++ b/server/api/v1/books/[slug].get.ts
@@ -1,5 +1,3 @@
-import { db } from '~/server/utils/db'
-
 export default defineEventHandler((event) => {
   const slug = getRouterParam(event, 'slug')
   const user = event.context.auth?.user

--- a/server/api/v1/books/[slug]/buy.post.ts
+++ b/server/api/v1/books/[slug]/buy.post.ts
@@ -1,5 +1,4 @@
 import { H3Event } from 'h3'
-import { db } from '~/server/utils/db'
 
 export default defineEventHandler(async (event: H3Event) => {
   // Step 1: Get the book slug from the URL

--- a/server/api/v1/books/my-purchases.get.ts
+++ b/server/api/v1/books/my-purchases.get.ts
@@ -1,5 +1,4 @@
 import { H3Event } from 'h3'
-import { db } from '~/server/utils/db'
 
 // Mock function to get book details. In a real app, this would query a database.
 const getBookDetails = (slug: string) => {

--- a/server/api/v1/downloads/[token].get.ts
+++ b/server/api/v1/downloads/[token].get.ts
@@ -1,5 +1,4 @@
 import { H3Event } from 'h3'
-import { db } from '~/server/utils/db'
 
 export default defineEventHandler(async (event: H3Event) => {
   const token = getRouterParam(event, 'token');


### PR DESCRIPTION
This commit fixes a critical application crash that occurred on startup.

The error was caused by using an incorrect import alias (`~/server/...`) within server-side API routes. This alias is not correctly resolved by the Nuxt/Nitro server, leading to an `ENOENT: no such file or directory` error.

The fix removes the explicit `import { db } from '...'` statements from the following four API endpoint handlers:
- `server/api/v1/books/[slug]/buy.post.ts`
- `server/api/v1/books/[slug].get.ts`
- `server/api/v1/books/my-purchases.get.ts`
- `server/api/v1/downloads/[token].get.ts`

The application now relies on Nuxt 3's built-in auto-import functionality for utilities located in the `server/utils` directory, which is the correct approach.

Additionally, this commit includes the installation of npm dependencies, as they were missing from the environment, which was required to run the application and verify the fix.