### PR TITLE
fix: correctly update purchase button state

### DIFF
--- a/app/pages/books/[slug].vue
+++ b/app/pages/books/[slug].vue
@@ -95,7 +95,7 @@ const fetchBook = async () => {
 }
 
 const handlePurchase = async () => {
-  if (!book.value) return;
+  if (!book.value || book.value.is_purchased) return;
   purchaseInProgress.value = true;
 
   const originalPurchaseStatus = book.value.is_purchased;
@@ -104,9 +104,8 @@ const handlePurchase = async () => {
   try {
     const response = await apiAuth.post(`/books/${slug}/buy`);
     alert(response.message || 'عملیات با موفقیت انجام شد.');
-    // Re-fetch in the background to get the full, updated book object from the server.
-    // This ensures data consistency if the user navigates away and back.
-    await fetchBook();
+    // Do NOT re-fetch here, to avoid getting a cached response from the GET endpoint.
+    // The optimistic update is now the source of truth for the UI for this session.
   } catch (err) {
     // Revert the optimistic update if the purchase fails
     book.value.is_purchased = originalPurchaseStatus;


### PR DESCRIPTION
This commit fixes a bug where the 'Buy' button was not being replaced by the 'Download' button after a successful purchase. This was caused by the frontend re-fetching book data immediately after purchase and receiving a stale, cached response from the backend API.

The solution is to remove the re-fetch call from the `handlePurchase` function and rely solely on an optimistic UI update. The `is_purchased` state is set to `true` immediately on the client, and this change is reverted only if the purchase API call fails.

This provides a correct and responsive user experience while working around the backend caching issue.