### PR TITLE
feat: add global 401 error handling and redirect guests

### DIFF
--- a/app/plugins/api.ts
+++ b/app/plugins/api.ts
@@ -1,0 +1,29 @@
+// app/plugins/api.ts
+import { ofetch } from 'ofetch';
+import { useAuthStore } from '~/stores/auth';
+
+export default defineNuxtPlugin((_nuxtApp) => {
+  globalThis.$fetch = ofetch.create({
+    onRequest({ options }) {
+      const authStore = useAuthStore();
+      if (authStore.token) {
+        options.headers = {
+          ...options.headers,
+          Authorization: `Bearer ${authStore.token}`,
+        };
+      }
+    },
+    onResponseError({ response }) {
+      // If a 401 Unauthorized error occurs, redirect to the login page
+      if (response.status === 401) {
+        const authStore = useAuthStore();
+        // Clear user data from the store
+        authStore.logout();
+        // Redirect to the auth page. Using navigateTo for client-side redirection.
+        // We use /auth because there is an auth.vue page, not login.vue
+        navigateTo('/auth', { replace: true });
+        alert('جلسه شما منقضی شده یا دسترسی ندارید. لطفاً دوباره وارد شوید.');
+      }
+    }
+  });
+});


### PR DESCRIPTION
This commit introduces a Nuxt plugin to globally handle API authentication and errors.

Following detailed user instructions, a new plugin at `plugins/api.ts` intercepts all `$fetch` calls.

1.  On `onRequest`, it automatically attaches the `Authorization: Bearer` token if the user is logged in.
2.  On `onResponseError`, it checks for a 401 status. If found, it logs the user out via the auth store and redirects to the `/auth` page.

This creates a robust, site-wide solution for authentication, ensuring that any user attempting an action that requires login is gracefully redirected.