### PR TITLE
fix: Use slug for purchase API call

### DIFF
--- a/app/pages/books/[slug].vue
+++ b/app/pages/books/[slug].vue
@@ -174,8 +174,8 @@ async function processPurchase() {
   purchaseInProgress.value = true;
   notification.value = { show: false, message: '', type: 'success' };
   try {
-    // Use book.id for the purchase request, which is more reliable than slug.
-    const response = await $fetch(`http://localhost:8000/api/v1/books/${book.value.id}/buy`, {
+    // The backend endpoint for purchasing expects the book's slug, not its ID.
+    const response = await $fetch(`http://localhost:8000/api/v1/books/${slug}/buy`, {
       method: 'POST',
       headers: { 'Authorization': `Bearer ${authStore.token}`, 'Accept': 'application/json' }
     });


### PR DESCRIPTION
The book purchase API endpoint `/api/v1/books/{identifier}/buy` expects the book's slug as the identifier, not its numeric ID.

This commit corrects the `processPurchase` function to use the `slug` from the route parameters instead of `book.value.id`. This resolves the "Book not found" error that occurred when clicking the purchase button.