### PR TITLE
fix: Correct data path for user_purchase_status

### DIFF
--- a/app/pages/books/[slug].vue
+++ b/app/pages/books/[slug].vue
@@ -129,7 +129,7 @@ async function fetchBook() {
 
     if (response.success && response.data?.book) {
       book.value = response.data.book;
-      purchaseStatus.value = response.data.book.user_purchase_status;
+      purchaseStatus.value = response.data.user_purchase_status;
       useHead({ title: response.data.book.title });
     } else {
       throw new Error('Invalid book data received from API.');


### PR DESCRIPTION
This commit fixes a bug where the purchase button was displayed incorrectly.

The `user_purchase_status` object was being read from the wrong path in the API response (`response.data.book.user_purchase_status` instead of `response.data.user_purchase_status`).

This change corrects the data access path, ensuring the component accurately reflects the user's purchase status (active, expired, or not purchased).