### PR TITLE
feat: Implement user library and download page

### DIFF
--- a/app/components/BookCard.vue
+++ b/app/components/BookCard.vue
@@ -16,24 +16,41 @@
         <h3 class="font-semibold text-gray-800 mb-1 line-clamp-1 hover:text-blue-600">{{ book.title }}</h3>
       </NuxtLink>
       <p class="text-sm text-gray-600 mb-2">{{ book.authors && book.authors.length > 0 ? book.authors[0].name : 'ناشناس' }}</p>
-      <div class="mt-auto flex items-center justify-between">
-        <div>
-          <p v-if="book.sale_price" class="text-xs text-gray-400 line-through">
-            {{ formatPrice(book.price) }}
-          </p>
-          <p class="text-lg font-bold text-green-600">
-            {{ formatPrice(book.sale_price || book.price) }}
-          </p>
+      <div class="mt-auto">
+        <!-- Download Links Section -->
+        <div v-if="showDownloadLinks" class="pt-4 border-t mt-4">
+          <h4 class="font-semibold text-sm mb-2 text-gray-700">دانلود کتاب:</h4>
+          <div v-if="book.downloads && book.downloads.length > 0" class="flex flex-wrap gap-2">
+            <a v-for="download in book.downloads"
+               :key="download.format"
+               :href="`/api/v1/downloads/${download.token}`"
+               download
+               class="bg-blue-600 text-white text-xs font-bold py-2 px-3 rounded hover:bg-blue-700 transition-colors">
+              {{ download.format.toUpperCase() }}
+            </a>
+          </div>
+          <div v-else>
+            <p class="text-xs text-gray-500">لینک‌های دانلود به زودی در دسترس خواهند بود.</p>
+          </div>
         </div>
 
-        <!-- Button Logic (to be replaced with Direct Purchase on book page) -->
-        <div class="relative">
-          <button v-if="book.is_purchased"
-                  disabled
-                  class="bg-gray-400 text-white text-xs font-bold py-2 px-3 rounded cursor-not-allowed">
-            خریداری شده
-          </button>
-          <!-- The "Add to cart" and "View cart" states have been removed. -->
+        <!-- Price/Purchase Section -->
+        <div v-else class="flex items-center justify-between pt-4">
+          <div>
+            <p v-if="book.sale_price" class="text-xs text-gray-400 line-through">
+              {{ formatPrice(book.price) }}
+            </p>
+            <p class="text-lg font-bold text-green-600">
+              {{ formatPrice(book.sale_price || book.price) }}
+            </p>
+          </div>
+          <div class="relative">
+            <button v-if="book.is_purchased"
+                    disabled
+                    class="bg-gray-400 text-white text-xs font-bold py-2 px-3 rounded cursor-not-allowed">
+              خریداری شده
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -45,6 +62,10 @@ const props = defineProps({
   book: {
     type: Object,
     required: true
+  },
+  showDownloadLinks: {
+    type: Boolean,
+    default: false
   }
 });
 

--- a/app/pages/dashboard/index.vue
+++ b/app/pages/dashboard/index.vue
@@ -1,66 +1,61 @@
 <template>
-  <div class="p-6" v-if="authStore.isLoggedIn && authStore.currentUser">
-    <h1 class="text-2xl font-bold mb-4">داشبورد</h1>
-    <p class="text-gray-600 mb-6">به داشبورد خوش آمدید!</p>
+  <div class="container mx-auto p-4 md:p-8">
+    <header class="mb-8">
+      <h1 class="text-3xl font-bold text-gray-800">کتابخانه من</h1>
+      <p class="text-gray-600 mt-2">کتاب‌هایی که خریداری کرده‌اید در اینجا نمایش داده می‌شوند.</p>
+    </header>
 
-    <!-- دکمه فقط برای ادمین -->
-    <div v-if="authStore.isAdmin" class="mb-4">
-      <button
-        class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition"
-        @click="performAdminAction"
-      >
-        مدیریت سیستم (فقط ادمین)
-      </button>
+    <div v-if="loading" class="text-center text-gray-500">
+      <p>در حال بارگذاری کتاب‌ها...</p>
     </div>
 
-    <!-- بقیه محتوا -->
-    <div>
-      <p>محتوای داشبورد برای همه کاربران...</p>
+    <div v-else-if="error" class="text-center text-red-500 p-4 bg-red-100 rounded-lg">
+      <p>خطا در دریافت اطلاعات: {{ error }}</p>
     </div>
 
-    <!-- نمایش JSON کاربر برای دیباگ -->
-    <div class="mt-6 bg-gray-100 p-4 rounded-lg">
-      <h2 class="text-xl font-semibold mb-2">اطلاعات کاربر وارد شده (برای دیباگ):</h2>
-      <pre class="whitespace-pre-wrap text-sm">{{ userInfo }}</pre>
-      <p class="text-red-600 mt-2">
-        وضعیت ادمین: {{ authStore.isAdmin ? 'بله (ادمین است)' : 'خیر (ادمین نیست)' }}
-      </p>
+    <div v-else-if="!purchaseStore.hasPurchases" class="text-center text-gray-500 p-8 border-2 border-dashed rounded-lg">
+      <h2 class="text-xl font-semibold">کتابی یافت نشد</h2>
+      <p class="mt-2">شما هنوز هیچ کتابی خریداری نکرده‌اید.</p>
+      <NuxtLink to="/books" class="mt-4 inline-block bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition">
+        مشاهده فروشگاه کتاب
+      </NuxtLink>
     </div>
-  </div>
 
-  <!-- نمایش پیام در حال بارگذاری یا لاگین نشده -->
-  <div v-else class="p-6 text-gray-500">
-    در حال بارگذاری اطلاعات کاربر یا شما لاگین نکرده‌اید...
+    <!-- The book list will be rendered here -->
+    <div v-else class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      <BookCard
+        v-for="book in purchasedBooks"
+        :key="book.id"
+        :book="book"
+        :show-download-links="true"
+      />
+    </div>
   </div>
 </template>
 
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useAuthStore } from '~/stores/auth'
-import { useApi } from '~/composables/useApi'
+import { usePurchaseStore } from '~/stores/purchase'
+import BookCard from '~/components/BookCard.vue'
 
 definePageMeta({ middleware: 'auth' })
 
 const authStore = useAuthStore()
-const api = useApi()
+const purchaseStore = usePurchaseStore()
 
+// Computed properties to reactively get data from the store
+const purchasedBooks = computed(() => purchaseStore.purchasedBooks)
+const loading = computed(() => purchaseStore.loading)
+const error = computed(() => purchaseStore.error)
+
+// Fetch user data and purchased books when the component mounts
 onMounted(async () => {
+  // Ensure user is fetched first, as their auth state is needed for the next call
   if (authStore.isLoggedIn && !authStore.currentUser) {
     await authStore.fetchUser()
   }
+  // Now fetch the purchased books
+  await purchaseStore.fetchPurchasedBooks()
 })
-
-const userInfo = computed(() => JSON.stringify(authStore.currentUser, null, 2) || 'هیچ اطلاعاتی موجود نیست')
-
-const performAdminAction = async () => {
-  try {
-    // The new structure has a /dashboard/index.get.ts. A DELETE endpoint for cache
-    // would logically be /dashboard/cache.delete.ts. I'll assume this or create it.
-    await api.delete('/dashboard/cache')
-    alert('عملیات ادمین با موفقیت انجام شد!')
-  } catch (error) {
-    console.error('خطا در عملیات ادمین:', error)
-    alert('خطایی رخ داد!')
-  }
-}
 </script>

--- a/app/stores/purchase.ts
+++ b/app/stores/purchase.ts
@@ -1,0 +1,44 @@
+import { defineStore } from 'pinia'
+import { useApiAuth } from '~/composables/useApiAuth'
+
+export const usePurchaseStore = defineStore('purchase', {
+  state: () => ({
+    purchasedBooks: [],
+    loading: false,
+    error: null,
+  }),
+
+  getters: {
+    hasPurchases: (state) => state.purchasedBooks.length > 0,
+  },
+
+  actions: {
+    async fetchPurchasedBooks() {
+      if (this.hasPurchases) {
+        // Data is already loaded
+        return;
+      }
+
+      this.loading = true;
+      this.error = null;
+      const api = useApiAuth();
+
+      try {
+        const response = await api.get('/books/my-purchases');
+        if (response.success && Array.isArray(response.data)) {
+          this.purchasedBooks = response.data;
+        } else {
+          // Handle cases where response.data is not as expected
+          this.purchasedBooks = [];
+          console.warn('API response for my-purchases was not in the expected format.', response);
+        }
+      } catch (error) {
+        console.error('Failed to fetch purchased books:', error);
+        this.error = error.response?._data?.message || 'An unexpected error occurred.';
+        this.purchasedBooks = []; // Clear data on error
+      } finally {
+        this.loading = false;
+      }
+    },
+  },
+})


### PR DESCRIPTION
This commit introduces the user library/downloads page and associated functionality.

- Creates a new Pinia store (`purchase.ts`) to manage the state of the user's purchased books.
- Implements an action in the store to fetch purchased books from the `GET /api/v1/books/my-purchases` endpoint.
- Refactors the dashboard page (`/dashboard`) to serve as the user's library. It now fetches and displays a grid of purchased books.
- The page handles loading, error, and empty states for a better user experience.
- Enhances the `BookCard.vue` component with a new `showDownloadLinks` prop.
- When on the dashboard, the book cards now display download links for available formats (e.g., PDF, EPUB) instead of price information. The download links point to the `GET /api/v1/downloads/{token}` endpoint.