### PR TITLE
fix: Use /downloads endpoint to fetch purchased books

### DIFF
--- a/app/stores/purchase.ts
+++ b/app/stores/purchase.ts
@@ -24,8 +24,8 @@ export const usePurchaseStore = defineStore('purchase', {
       const api = useApiAuth();
 
       try {
-        // Switched to the alternative endpoint as /books/my-purchases returned 404
-        const response = await api.get('/purchase/purchases');
+        // Switched to /downloads as /purchase/purchases returned a 500 error.
+        const response = await api.get('/downloads');
         if (response.success && Array.isArray(response.data)) {
           this.purchasedBooks = response.data;
         } else {


### PR DESCRIPTION
This commit resolves a 500 Internal Server Error on the 'My Purchases' page.

Previous attempts to use `/books/my-purchases` (404) and `/purchase/purchases` (500) failed due to backend issues.

The implementation is now updated to use the `GET /api/v1/downloads` endpoint, which is the correct and working API for fetching the user's downloadable books. This ensures the page can successfully fetch and display the user's library.