### PR TITLE
chore: Add debug block to my-purchases page

### DIFF
--- a/app/pages/my-purchases.vue
+++ b/app/pages/my-purchases.vue
@@ -29,6 +29,18 @@
         :show-download-links="true"
       />
     </div>
+
+    <!-- Debug Information Block -->
+    <div class="mt-8 p-4 bg-gray-800 text-white rounded-lg font-mono text-left text-sm" dir="ltr">
+      <h3 class="font-bold text-lg mb-2">DEBUG INFORMATION (Purchase Store)</h3>
+      <pre>{{ {
+        loading: purchaseStore.loading,
+        error: purchaseStore.error,
+        hasPurchases: purchaseStore.hasPurchases,
+        purchasedBooksCount: purchaseStore.purchasedBooks.length,
+        purchasedBooks: purchaseStore.purchasedBooks
+      } }}</pre>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
To diagnose an issue where purchased books are not being displayed, this commit adds a debug section to the bottom of the `/my-purchases` page.

This section prints the reactive state of the `purchaseStore`, including the loading status, any errors, and the content of the `purchasedBooks` array. This will allow for easier debugging of the data flow from the API to the component.