### PR TITLE
fix: Handle paginated response for purchased books

### DIFF
--- a/app/pages/my-purchases.vue
+++ b/app/pages/my-purchases.vue
@@ -30,17 +30,6 @@
       />
     </div>
 
-    <!-- Debug Information Block -->
-    <div class="mt-8 p-4 bg-gray-800 text-white rounded-lg font-mono text-left text-sm" dir="ltr">
-      <h3 class="font-bold text-lg mb-2">DEBUG INFORMATION (Purchase Store)</h3>
-      <pre>{{ {
-        loading: purchaseStore.loading,
-        error: purchaseStore.error,
-        hasPurchases: purchaseStore.hasPurchases,
-        purchasedBooksCount: purchaseStore.purchasedBooks.length,
-        purchasedBooks: purchaseStore.purchasedBooks
-      } }}</pre>
-    </div>
   </div>
 </template>
 

--- a/app/stores/purchase.ts
+++ b/app/stores/purchase.ts
@@ -24,14 +24,13 @@ export const usePurchaseStore = defineStore('purchase', {
       const api = useApiAuth();
 
       try {
-        // Switched to /downloads as /purchase/purchases returned a 500 error.
         const response = await api.get('/downloads');
-        if (response.success && Array.isArray(response.data)) {
-          this.purchasedBooks = response.data;
+        // The API returns a paginated response, so the book list is in `response.data.data`
+        if (response.success && response.data && Array.isArray(response.data.data)) {
+          this.purchasedBooks = response.data.data;
         } else {
-          // Handle cases where response.data is not as expected
           this.purchasedBooks = [];
-          console.warn('API response for my-purchases was not in the expected format.', response);
+          console.warn('API response for downloads was not in the expected paginated format.', response);
         }
       } catch (error) {
         console.error('Failed to fetch purchased books:', error);


### PR DESCRIPTION
This commit fixes the final bug on the 'My Purchases' page where books were not being displayed.

The API returns a standard paginated response object, but the frontend was expecting a simple array. The logic in the `purchase.ts` store has been updated to correctly extract the list of books from the `data.data` key of the response.

Additionally, the temporary debug block has been removed from the `my-purchases.vue` page. This should make the feature fully functional.