### PR TITLE
feat: Implement 'My Purchased Books' page

### DIFF
--- a/components/PurchasedBookCard.vue
+++ b/components/PurchasedBookCard.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="border border-gray-200 rounded-lg shadow-lg overflow-hidden flex flex-col h-full bg-white transition-shadow hover:shadow-xl">
+    <!-- Book Cover Image -->
+    <div class="relative h-56 w-full bg-gray-100">
+      <img
+        :src="purchase.cover_image_url || '/images/default-book-cover.png'"
+        :alt="`جلد کتاب ${purchase.title}`"
+        class="w-full h-full object-cover"
+      />
+    </div>
+
+    <!-- Card Content -->
+    <div class="p-4 flex flex-col flex-grow">
+      <h3 class="text-lg font-bold text-gray-800 mb-2 flex-grow">
+        {{ purchase.title }}
+      </h3>
+
+      <div class="space-y-2 text-sm text-gray-600 mt-2 mb-4">
+        <!-- Remaining Downloads -->
+        <div class="flex items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+          <span>تعداد دانلود باقی‌مانده: <strong>{{ purchase.remaining_downloads }}</strong></span>
+        </div>
+
+        <!-- Expiration Info -->
+        <div v-if="expirationText" class="flex items-center" :class="expirationClass">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+          <span>{{ expirationText }}</span>
+        </div>
+      </div>
+
+      <!-- Download Button -->
+      <a
+        :href="isExpired ? undefined : purchase.download_url"
+        :target="isExpired ? undefined : '_blank'"
+        rel="noopener noreferrer"
+        :class="[
+          'w-full text-center font-bold py-2 px-4 rounded-lg mt-auto transition-colors',
+          {
+            'bg-blue-600 hover:bg-blue-700 text-white': !isExpired,
+            'bg-gray-300 text-gray-500 cursor-not-allowed': isExpired
+          }
+        ]"
+        :aria-disabled="isExpired"
+      >
+        {{ isExpired ? 'لینک منقضی شده' : 'دانلود کتاب' }}
+      </a>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+// Define the structure for the prop for type safety
+interface BookPurchase {
+  id: number;
+  title: string;
+  cover_image_url: string | null;
+  remaining_downloads: number;
+  days_until_expiration: number | null;
+  download_url: string;
+}
+
+// Define the props this component accepts
+const props = defineProps({
+  purchase: {
+    type: Object as () => BookPurchase,
+    required: true
+  }
+});
+
+// Computed property to check if the download link is expired
+const isExpired = computed(() => {
+  return props.purchase.days_until_expiration !== null && props.purchase.days_until_expiration < 0;
+});
+
+// Computed property to generate the expiration text
+const expirationText = computed(() => {
+  const days = props.purchase.days_until_expiration;
+  if (days === null) {
+    // If null, the link is permanent and we show nothing.
+    return 'لینک دانلود دائمی است';
+  }
+  if (days < 0) {
+    return 'لینک منقضی شده است';
+  }
+  if (days === 0) {
+    return 'امروز آخرین فرصت دانلود است';
+  }
+  return `زمان باقی‌مانده: ${days} روز`;
+});
+
+// Computed property to apply different text colors based on expiration status
+const expirationClass = computed(() => {
+  const days = props.purchase.days_until_expiration;
+  if (days !== null && days < 0) {
+    return 'text-red-600 font-semibold'; // Expired
+  }
+  if (days !== null && days < 7) {
+    return 'text-yellow-700'; // Expiring soon
+  }
+  return 'text-gray-600'; // Normal
+});
+</script>
+
+<style scoped>
+/* Using Tailwind utility classes, so minimal custom CSS is needed. */
+/* You can add custom styles here if required. */
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
+</style>

--- a/pages/my-purchases/index.vue
+++ b/pages/my-purchases/index.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="container mx-auto p-4 md:p-8">
+    <h1 class="text-3xl font-bold mb-8 text-gray-800 border-b pb-4">
+      کتاب‌های خریداری شده من
+    </h1>
+
+    <!-- 1. Loading State -->
+    <div v-if="pending">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        <!-- Skeleton Loader Card -->
+        <div v-for="i in 4" :key="i" class="border rounded-lg p-4 shadow-md animate-pulse">
+          <div class="bg-gray-300 h-48 w-full rounded-md mb-4"></div>
+          <div class="h-6 bg-gray-300 rounded w-3/4 mb-2"></div>
+          <div class="h-4 bg-gray-300 rounded w-1/2 mb-4"></div>
+          <div class="h-10 bg-gray-300 rounded w-full"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 2. Error State -->
+    <div v-else-if="error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg relative" role="alert">
+      <strong class="font-bold">خطا!</strong>
+      <span class="block sm:inline"> متاسفانه در دریافت اطلاعات مشکلی پیش آمد. لطفا دوباره تلاش کنید.</span>
+      <p class="text-sm mt-2 text-gray-600">{{ error.message }}</p>
+    </div>
+
+    <!-- 3. Empty State -->
+    <div v-else-if="!purchases || purchases.length === 0" class="text-center py-16">
+      <p class="text-xl text-gray-600 mb-4">شما هنوز هیچ کتابی خریداری نکرده‌اید.</p>
+      <NuxtLink to="/store" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-6 rounded-lg transition-colors">
+        رفتن به فروشگاه
+      </NuxtLink>
+    </div>
+
+    <!-- 4. Success State - Display Books -->
+    <div v-else>
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
+        <PurchasedBookCard
+          v-for="purchase in purchases"
+          :key="purchase.id"
+          :purchase="purchase"
+        />
+      </div>
+      <!-- Pagination can be added here later using the 'meta' and 'links' objects -->
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Define the structure for a single purchase object for type safety
+interface BookPurchase {
+  id: number;
+  title: string;
+  cover_image_url: string | null;
+  remaining_downloads: number;
+  days_until_expiration: number | null;
+  download_url: string;
+  book: {
+    id: number;
+    slug: string;
+    // ... other book details
+  };
+}
+
+// Define the structure for the API response
+interface ApiResponse {
+  data: BookPurchase[];
+  links: Record<string, string | null>;
+  meta: Record<string, any>;
+}
+
+// Set page title and meta description
+useHead({
+  title: 'کتاب‌های خریداری شده من',
+  meta: [
+    { name: 'description', content: 'لیست کتاب‌های خریداری شده و لینک‌های دانلود آن‌ها.' }
+  ]
+})
+
+// Fetch data from the API using Nuxt's useFetch composable
+// It automatically handles server-side rendering, caching, and state management (pending, error, data)
+const { data: response, pending, error } = await useFetch<ApiResponse>('/api/v1/downloads', {
+  // Assuming authentication is handled globally by a Nuxt plugin (e.g., for Sanctum)
+  // If not, you would add headers here:
+  // headers: { 'Authorization': `Bearer ${token}` }
+  lazy: true, // `lazy: true` means it won't block navigation on the client-side
+});
+
+// Computed property to safely access the list of purchases from the response
+const purchases = computed(() => response.value?.data || []);
+
+// You can also access pagination info if needed in the future
+// const pagination = computed(() => response.value?.meta);
+
+</script>
+
+<style scoped>
+/* Scoped styles can be added here if needed */
+</style>


### PR DESCRIPTION
This commit introduces the 'My Purchased Books' page, allowing users to view a list of their purchased books and access download links.

The new page is located at the `/my-purchases` route and is built using Nuxt 4 and Vue 3's Composition API. It fetches data from the `/api/v1/downloads` endpoint using the `useFetch` composable, which handles server-side rendering and state management.

The page includes robust state handling:
- A skeleton loader is shown while data is being fetched.
- An error message is displayed if the API call fails.
- An empty state message with a link to the store is shown if the user has no purchases.

A new reusable component, `PurchasedBookCard.vue`, has been created to display the details of each book. This component shows the cover image (with a fallback), title, remaining downloads, and a dynamically calculated expiration status (permanent, expiring soon, or expired). The download button is correctly disabled for expired links.

The implementation uses TypeScript for type safety and follows a clean, component-based architecture.