### PR TITLE
chore: Trivial change to force re-sync

### DIFF
--- a/pages/my-purchases/index.vue
+++ b/pages/my-purchases/index.vue
@@ -96,6 +96,7 @@
 </template>
 
 <script setup lang="ts">
+// Trivial change to force a re-sync.
 import { storeToRefs } from 'pinia';
 import { usePurchaseStore } from '~/app/stores/purchase';
 


### PR DESCRIPTION
Adds a comment to `pages/my-purchases/index.vue`. This non-functional change is intended to create a new commit to help with troubleshooting a local environment synchronization issue.