### PR TITLE
feat: Redesign 'My Purchases' page and add final polish

### DIFF
--- a/app/pages/my-purchases.vue
+++ b/app/pages/my-purchases.vue
@@ -57,7 +57,9 @@
                   <img class="h-10 w-10 rounded-full object-cover" :src="purchase.cover_image_url || '/placeholder.png'" :alt="purchase.title">
                 </div>
                 <div class="mr-4">
-                  <div class="text-sm font-medium text-gray-900">{{ purchase.title }}</div>
+                  <NuxtLink :to="purchase.renew_url" class="text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors">
+                    {{ purchase.title }}
+                  </NuxtLink>
                 </div>
               </div>
             </td>
@@ -68,7 +70,7 @@
                 :class="purchase.is_expired ? 'text-red-800' : 'text-green-800'"
                 class="font-semibold"
               >
-                {{ purchase.is_expired ? 'منقضی شده' : `${purchase.days_until_expiration} روز باقی‌مانده` }}
+                {{ purchase.is_expired ? 'منقضی شده' : `${Math.floor(purchase.days_until_expiration)} روز باقی‌مانده` }}
               </span>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden lg:table-cell">{{ purchase.remaining_downloads }}</td>


### PR DESCRIPTION
This commit enhances the 'My Purchases' page. It builds upon the recent redesign from a card grid to a responsive table.

The following changes are included:
- The book title in the purchases table is now a clickable link, directing the user to the book's detail page using the `renew_url`.
- The 'days until expiration' value is now rounded down using `Math.floor()` to ensure it's always displayed as a whole number.
- Replaced the card grid in `my-purchases.vue` with a responsive `<table>`.
- Table rows are color-coded based on the `is_expired` status.
- The 'Actions' column conditionally shows a 'Download' or 'Renew' link.
- Refactored the Pinia store (`purchase.ts`) for the new API structure.
- Added `formatDate` and `formatCurrency` helpers to `useFormatters.ts`.