### PR TITLE
feat: Add debug view to 'My Purchases' page

### DIFF
--- a/app/pages/my-purchases.vue
+++ b/app/pages/my-purchases.vue
@@ -82,6 +82,12 @@
         </tbody>
       </table>
     </div>
+
+    <!-- Debug View -->
+    <div v-if="purchases.length > 0" class="mt-12 p-4 bg-gray-800 text-white rounded-lg" dir="ltr">
+      <h3 class="text-lg font-bold mb-2 text-right">Debug View: Raw API Data</h3>
+      <pre class="text-xs whitespace-pre-wrap break-all">{{ JSON.stringify(purchases, null, 2) }}</pre>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
This commit adds a debug section to the bottom of the 'My Purchases' page. This section displays the raw JSON data for the `purchases` array, helping with the debugging of API-related issues by showing the exact data received by the frontend.

This commit builds upon the previous redesign of the page and includes:
- A new 'Debug View' section that renders the raw `purchases` data.
- The book title in the table is a clickable link to the book's detail page.
- The 'days until expiration' value is rounded down to a whole number.
- A responsive table layout for displaying purchases.
- Conditional styling and actions based on purchase status.
- Refactored Pinia store and new formatter functions.