### PR TITLE
fix: Revert 'buy' API endpoint to use plural 'books'

### DIFF
--- a/app/pages/book/[slug].vue
+++ b/app/pages/book/[slug].vue
@@ -173,7 +173,7 @@ async function processPurchase() {
   notification.value = { show: false, message: '', type: 'success' };
 
   try {
-    const response = await $fetch(`http://localhost:8000/api/v1/book/${slug}/buy`, {
+    const response = await $fetch(`http://localhost:8000/api/v1/books/${slug}/buy`, {
       method: 'POST',
       headers: { 'Authorization': `Bearer ${authStore.token}`, 'Accept': 'application/json' }
     });


### PR DESCRIPTION
This commit corrects a bug where the 'buy' button on the single book page was calling an incorrect API endpoint (`.../book/.../buy`), leading to a 'Route not found' error.

The API call in the `processPurchase` function has been reverted to use the correct, plural endpoint (`.../books/{slug}/buy`) as expected by the backend. The endpoint for fetching book data remains singular (`.../book/{slug}`). This aligns the frontend with the backend's API structure.