### PR TITLE
fix: Invalidate purchase list after buying a book

### DIFF
--- a/app/pages/book/[slug].vue
+++ b/app/pages/book/[slug].vue
@@ -95,10 +95,12 @@
 <script setup>
 import { ref, computed, watch } from 'vue';
 import { useAuthStore } from '~/stores/auth';
+import { usePurchaseStore } from '~/stores/purchase';
 
 const route = useRoute();
 const slug = route.params.slug;
 const authStore = useAuthStore();
+const purchaseStore = usePurchaseStore();
 
 // State for the component
 const book = ref(null);
@@ -179,6 +181,7 @@ async function processPurchase() {
     });
     // On success, show a notification and refetch the book data to update the state.
     notification.value = { show: true, message: response.message || 'خرید با موفقیت انجام شد!', type: 'success' };
+    purchaseStore.clearPurchases(); // Invalidate the purchases list
     await fetchBook(); // Refetch data to get the new purchase status
   } catch (err) {
     notification.value = { show: true, message: err.response?._data?.message || 'خطایی در هنگام خرید رخ داد.', type: 'error' };

--- a/app/stores/purchase.ts
+++ b/app/stores/purchase.ts
@@ -40,5 +40,9 @@ export const usePurchaseStore = defineStore('purchase', {
         this.loading = false;
       }
     },
+
+    clearPurchases() {
+      this.purchases = [];
+    },
   },
 })


### PR DESCRIPTION
This commit fixes a state synchronization bug where the 'My Purchases' page would not show a newly purchased book without a manual refresh.

The fix implements the following:
1.  A `clearPurchases` action has been added to the `usePurchaseStore` to invalidate the cached list of purchases.
2.  This action is now called from the single book page after a successful purchase is made.

This ensures that when the user navigates back to the 'My Purchases' page, a fresh, up-to-date list of books is fetched from the server, providing a seamless user experience.