### PR TITLE
feat(auth): Add OTP login option on password screen

### DIFF
--- a/app/pages/auth.vue
+++ b/app/pages/auth.vue
@@ -41,9 +41,9 @@
             <button type="submit" :disabled="loading" class="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition disabled:opacity-50 mb-3">
               {{ loading ? 'در حال ورود...' : 'ورود با رمز عبور' }}
             </button>
-            <!-- OTP login is not a valid flow for users who already have a password. -->
-            <!-- To use OTP, they should use a "Forgot Password" flow which would then trigger an OTP. -->
-            <!-- Removing this button prevents the "Invalid code" error from the backend. -->
+            <button type="button" @click="handleRequestOtp" :disabled="loading" class="w-full text-center text-sm text-blue-600 hover:text-blue-700 disabled:text-gray-400">
+              ورود با کد یکبار مصرف
+            </button>
           </form>
         </div>
 
@@ -250,18 +250,9 @@ const handleRequestOtp = async (showLoading = true) => {
 const handleVerifyOtp = async () => {
   error.value = ''
   loading.value = true
-  const isNewUser = !checkUserResponse.value?.user_exists
-
   try {
-    // Always call verifyOtp without the name.
-    // The backend test OTP '123456' likely only works on this endpoint signature.
-    await authStore.verifyOtp(identifier.value, otp.value)
-
-    // If it was a new user, update their name now that they are logged in.
-    if (isNewUser && userName.value) {
-      await authStore.updateProfile({ name: userName.value })
-    }
-
+    const nameToSend = checkUserResponse.value?.user_exists ? undefined : userName.value
+    await authStore.verifyOtp(identifier.value, otp.value, nameToSend)
     await router.push('/dashboard')
   } catch (err: any) {
     error.value = err.data?.message || 'کد تایید اشتباه است.'

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -60,9 +60,12 @@ export const useAuthStore = defineStore('auth', {
       return await api.post('/auth/send-otp', { identifier });
     },
 
-    async verifyOtp(identifier: string, otp: string) {
+    async verifyOtp(identifier: string, otp: string, name?: string) {
       const api = useApiAuth();
-      const payload = { identifier, otp };
+      const payload: { identifier: string; otp: string; name?: string } = { identifier, otp };
+      if (name) {
+        payload.name = name;
+      }
       const response = await api.post('/auth/verify-otp', payload);
       this.setAuth(response);
       return response;


### PR DESCRIPTION
As per the user's request and the updated API documentation, this commit adds a "Login with one-time code" button to the password entry screen.

This allows users who have an existing account with a password to choose to log in via OTP instead of entering their password.

The button was previously commented out due to a misunderstanding of the backend's capabilities, but has now been restored.