### PR TITLE
fix(auth): Refresh user state after password change

### DIFF
--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -104,12 +104,16 @@ export const useAuthStore = defineStore('auth', {
 
     async setPassword(password: string, password_confirmation: string) {
       const api = useApiAuth();
-      return await api.post('/auth/password/set', { password, password_confirmation });
+      const response = await api.post('/auth/password/set', { password, password_confirmation });
+      await this.fetchUser();
+      return response;
     },
 
     async updatePassword(current_password: string, password: string, password_confirmation: string) {
       const api = useApiAuth();
-      return await api.post('/auth/password/update', { current_password, password, password_confirmation });
+      const response = await api.post('/auth/password/update', { current_password, password, password_confirmation });
+      await this.fetchUser();
+      return response;
     },
 
     async refreshToken() {


### PR DESCRIPTION
The user's password status on the profile page was not updating without a manual refresh. This was because the `setPassword` and `updatePassword` actions in the auth store did not update the local user state after the API call.

This commit fixes the issue by calling `fetchUser()` after a successful password set or update. This ensures the local user state is synchronized with the server, and the UI updates reactively as expected.