### PR TITLE
fix: Address multiple state and logic issues on profile page

### DIFF
--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -145,7 +145,7 @@
                         </svg>
                       </div>
                     </div>
-                    <div v-if="!user?.email_verified_at && form.email && form.email !== user?.email"
+                    <div v-if="!user?.email_verified_at && form.email"
                          class="flex justify-end">
                       <button
                         type="button"
@@ -192,7 +192,7 @@
                         </svg>
                       </div>
                     </div>
-                    <div v-if="!user?.phone_verified_at && form.phone && form.phone !== user?.phone"
+                    <div v-if="!user?.phone_verified_at && form.phone"
                          class="flex justify-end">
                       <button
                         type="button"
@@ -892,11 +892,14 @@ const handleEmailVerification = async () => {
   if (!form.value.email) return
   emailVerificationSending.value = true
   try {
-    await apiAuth.post('/email/send-verification', { email: form.value.email })
+    // First, save the new email to the profile
+    await updateProfile()
+    // Then, send the verification code
+    await apiAuth.post('/auth/send-otp', { identifier: form.value.email })
     verificationModal.value = { type: 'email', target: form.value.email }
     showVerificationModal.value = true
   } catch (error) {
-    showMessage('خطا در ارسال کد تایید ایمیل', 'error')
+    showMessage(error.data?.message || 'خطا در ارسال کد تایید ایمیل', 'error')
   } finally {
     emailVerificationSending.value = false
   }
@@ -906,11 +909,14 @@ const handlePhoneVerification = async () => {
   if (!form.value.phone) return
   smsVerificationSending.value = true
   try {
-    await apiAuth.post('/phone/send-verification', { phone: form.value.phone })
+    // First, save the new phone number to the profile
+    await updateProfile()
+    // Then, send the verification code
+    await apiAuth.post('/auth/send-otp', { identifier: form.value.phone })
     verificationModal.value = { type: 'phone', target: form.value.phone }
     showVerificationModal.value = true
   } catch (error) {
-    showMessage('خطا در ارسال کد تایید موبایل', 'error')
+    showMessage(error.data?.message || 'خطا در ارسال کد تایید موبایل', 'error')
   } finally {
     smsVerificationSending.value = false
   }


### PR DESCRIPTION
This commit provides a comprehensive fix for several issues identified on the user profile page:

1.  **Password Status UI Not Updating:**
    - The UI would not reflect that a password had been set without a manual page refresh.
    - This is fixed in `app/stores/auth.ts` by calling `fetchUser()` after the `setPassword` and `updatePassword` actions, ensuring the client-side user state is synchronized with the backend.

2.  **Verification API Call Failing (404 Error):**
    - The "Send verification code" buttons for email and phone were calling non-existent API endpoints (`/phone/send-verification`).
    - This is fixed by changing the API calls in `app/pages/profile.vue` to use the correct, unified endpoint: `/auth/send-otp`.

3.  **Verification Logic Flow Error:**
    - The verification code was being requested for a new phone/email *before* that information was saved to the user's profile, causing backend errors.
    - This is fixed by updating the `handlePhoneVerification` and `handleEmailVerification` functions to first call `updateProfile()` before requesting the OTP.

4.  **Verification Button Disappearing:**
    - The "Send verification code" button would incorrectly disappear after a user saved a new, unverified phone number or email.
    - This is fixed by correcting the `v-if` logic in the template to ensure the button remains visible for any unverified contact method that is present in the form.