### PR TITLE
fix: Comprehensive fixes for profile page state, logic, and API calls

### DIFF
--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -925,20 +925,14 @@ const handlePhoneVerification = async () => {
 const verifyCode = async () => {
   if (!verificationCode.value || verificationCode.value.length !== 6) return
   loading.value = true
+  clearMessage()
   try {
-    let response;
-    if (verificationModal.value.type === 'email') {
-      response = await apiAuth.post('/email/verify', { email: verificationModal.value.target, otp: verificationCode.value })
-      showMessage('ایمیل با موفقیت تایید شد', 'success')
-    } else {
-      response = await apiAuth.post('/phone/verify', { phone: verificationModal.value.target, otp: verificationCode.value })
-      showMessage('شماره موبایل با موفقیت تایید شد', 'success')
-    }
-    if (response) {
-      authStore.setUser(response.user || response)
-      populateForm(response.user || response) // Repopulate form with new data
-    }
+    // Use the central auth store action, which handles the API call and state update
+    await authStore.verifyOtp(verificationModal.value.target, verificationCode.value)
+
+    showMessage('تایید با موفقیت انجام شد.', 'success')
     closeVerificationModal()
+    // The user object in the store is now updated, and the page will be reactive.
   } catch (error) {
     showMessage(error.data?.message || 'کد تایید اشتباه است', 'error')
   } finally {


### PR DESCRIPTION
This commit provides a comprehensive fix for several issues identified on the user profile page, addressing all user-reported bugs in this session.

1.  **Password Status UI Not Updating:**
    - The UI would not reflect that a password had been set without a manual page refresh.
    - This is fixed in `app/stores/auth.ts` by calling `fetchUser()` after the `setPassword` and `updatePassword` actions, ensuring the client-side user state is synchronized with the backend.

2.  **Verification API Call Failing (404 Error):**
    - The "Send verification code" and "Verify code" buttons were calling non-existent API endpoints.
    - This is fixed by changing the API calls in `app/pages/profile.vue` to use the correct, unified endpoints as defined in the API documentation: `/auth/send-otp` and `/auth/verify-otp`.

3.  **Verification Logic Flow Error:**
    - The verification code was being requested for a new phone/email *before* that information was saved to the user's profile, causing backend errors.
    - This is fixed by updating the `handle...Verification` functions to first call `updateProfile()` before requesting the OTP.

4.  **Verification Button Disappearing:**
    - The "Send verification code" button would incorrectly disappear after a user saved a new, unverified phone number or email.
    - This is fixed by correcting the `v-if` logic in the template to ensure the button remains visible for any unverified contact method that is present in the form.

5.  **OTP Verification State Handling:**
    - The `verifyCode` function was updated to use the central `authStore.verifyOtp` action to ensure that authentication tokens and user state are managed correctly after a successful verification.