### PR TITLE
fix: Correct download link logic on purchases page

### DIFF
--- a/app/pages/my-purchases.vue
+++ b/app/pages/my-purchases.vue
@@ -75,9 +75,9 @@
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden lg:table-cell">{{ purchase.remaining_downloads }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-              <div v-if="!purchase.is_expired && purchase.download_token">
+              <div v-if="!purchase.is_expired && purchase.download_url">
                 <NuxtLink
-                  :to="`/book/download/${purchase.download_token}`"
+                  :to="`/book/download/${getDownloadTokenFromUrl(purchase.download_url)}`"
                   class="text-indigo-600 hover:text-indigo-900"
                 >
                   دانلود
@@ -118,6 +118,18 @@ definePageMeta({
 const authStore = useAuthStore()
 const purchaseStore = usePurchaseStore()
 const formatters = useFormatters()
+
+const getDownloadTokenFromUrl = (url) => {
+  if (!url) return ''
+  try {
+    const urlObject = new URL(url)
+    const pathSegments = urlObject.pathname.split('/')
+    return pathSegments.pop() || ''
+  } catch (e) {
+    console.error('Invalid download URL:', url, e)
+    return ''
+  }
+}
 
 // Computed properties to reactively get data from the store
 const purchases = computed(() => purchaseStore.purchases)


### PR DESCRIPTION
This commit fixes a bug where the download button on the 'My Purchases' page was incorrectly showing 'Unavailable'.

The issue was caused by the code checking for a `download_token` property, but the API was returning a full `download_url`.

The fix involves:
- Updating the `my-purchases.vue` component to check for the `download_url` property instead.
- Adding a helper function to safely extract the download token from the end of the `download_url`.
- Using the extracted token to construct the correct link to the dedicated download page.