### PR TITLE
feat: Add temporary debug view to processing state

### DIFF
--- a/app/pages/book/download/[token].vue
+++ b/app/pages/book/download/[token].vue
@@ -29,6 +29,12 @@
           </p>
         </div>
         <p class="text-sm text-blue-600 mt-2">این صفحه به صورت خودکار به‌روزرسانی می‌شود.</p>
+
+        <!-- Temporary Debug View -->
+        <div class="mt-4 p-2 bg-blue-100 border border-blue-300 text-left text-xs" dir="ltr">
+          <h4 class="font-bold text-blue-800">Debug Info (API Response):</h4>
+          <pre class="whitespace-pre-wrap break-all">{{ JSON.stringify(downloadInfo, null, 2) }}</pre>
+        </div>
       </div>
 
       <!-- Available State -->


### PR DESCRIPTION
This commit adds a temporary debug view to the download page. As requested by the user, this view is displayed only when the page is in the 'processing' or 'unavailable' state.

It displays the entire `downloadInfo` object received from the backend API, which will help the user diagnose issues with file paths and database information by showing them exactly what data the frontend has available.