### PR TITLE
fix: Correct API path for merge functionality

### DIFF
--- a/app/pages/admin/books.vue
+++ b/app/pages/admin/books.vue
@@ -139,7 +139,7 @@ const handleMerge = async ({ master_id, slave_ids }) => {
   mergeLoading.value = true;
   mergeError.value = null;
   try {
-    await api.post('/api/admin/merge', {
+    await api.post('/admin/merge', {
       master_id,
       slave_ids,
       type: 'book'


### PR DESCRIPTION
Corrects the API endpoint path for the book merge feature in the admin panel.

The previous implementation was calling `/api/admin/merge`, which was being incorrectly prefixed to `/api/v1/api/admin/merge` by the API composable.

This commit changes the path to `/admin/merge`, which correctly resolves to the intended `/api/v1/admin/merge` endpoint. This fixes the 500 error that was occurring when trying to merge books.