### PR TITLE
feat: add API debugger and fix initialization error

### DIFF
--- a/app/composables/useApiDebugger.ts
+++ b/app/composables/useApiDebugger.ts
@@ -17,9 +17,10 @@ export interface ApiLog {
 }
 
 // Create a reactive state to store API logs
-const apiLogs = useState<ApiLog[]>('api-logs', () => [])
 
 export const useApiDebugger = () => {
+  const apiLogs = useState<ApiLog[]>('api-logs', () => [])
+
   const addLog = (log: Omit<ApiLog, 'id' | 'startTime'>) => {
     const newLog: ApiLog = {
       ...log,


### PR DESCRIPTION
This change introduces a new API debugger to help with development and debugging. It includes:
- A new `ApiDebugger.vue` component to display API logs.
- A new `useApiDebugger.ts` composable to manage the state of the logs.
- Modifications to `useApi.ts` to intercept and log all API requests and responses.

The debugger is added to the default layout and is only visible in development mode.

This commit also fixes a bug where `useState` was called outside of a valid Nuxt context, which caused the application to crash with a white screen. The `useState` call has been moved inside the composable function to ensure it is called within the correct context.