### PR TITLE
fix: rework API debugger to resolve logging issues

### DIFF
--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -16,17 +16,13 @@ export const useApi = () => {
       'Accept': 'application/json',
     },
     onRequest({ request, options }) {
-      const logId = Math.random().toString(36).substr(2, 9)
-      options.headers = options.headers || {}
-      options.headers['X-Request-ID'] = logId
-
-      addLog({
-        id: logId,
+      const newLog = addLog({
         method: options.method || 'GET',
         url: request.toString(),
         request: options.body,
-        startTime: Date.now(),
       })
+      options.headers = options.headers || {}
+      options.headers['X-Request-ID'] = newLog.id
     },
     onResponse({ request, response, options }) {
       const logId = options.headers['X-Request-ID']

--- a/app/composables/useApiDebugger.ts
+++ b/app/composables/useApiDebugger.ts
@@ -5,7 +5,7 @@ import { useState } from '#app'
 export interface ApiLog {
   id: string;
   method: string;
-  url: string;
+  url:string;
   startTime: number;
   endTime?: number;
   duration?: number;
@@ -16,18 +16,23 @@ export interface ApiLog {
   statusText?: string;
 }
 
-// Create a reactive state to store API logs
-
 export const useApiDebugger = () => {
   const apiLogs = useState<ApiLog[]>('api-logs', () => [])
 
-  const addLog = (log: Omit<ApiLog, 'id' | 'startTime'>) => {
+  const addLog = (log: Omit<ApiLog, 'id' | 'startTime' | 'status' | 'statusText' | 'response' | 'error' | 'endTime' | 'duration'>): ApiLog => {
     const newLog: ApiLog = {
       ...log,
       id: Math.random().toString(36).substr(2, 9),
       startTime: Date.now(),
+      status: undefined,
+      statusText: undefined,
+      response: undefined,
+      error: undefined,
+      endTime: undefined,
+      duration: undefined,
     }
     apiLogs.value.unshift(newLog)
+    return newLog
   }
 
   const updateLog = (id: string, updates: Partial<ApiLog>) => {


### PR DESCRIPTION
This commit refactors the API debugger to fix a critical bug where response data was not being correctly associated with its request.

- The `useApiDebugger` composable has been updated to have `addLog` be the single source of truth for creating and ID-ing a new log entry.
- The `useApi` composable has been updated to use the new `addLog` function correctly, ensuring the request ID is retrieved from the newly created log object.

This should resolve the issue where the debugger appeared empty or incomplete.