### PR TITLE
fix: Correct admin endpoint and refactor book page API calls

### DIFF
--- a/app/pages/admin/books.vue
+++ b/app/pages/admin/books.vue
@@ -160,7 +160,7 @@ const fetchBooks = async () => {
   error.value = null;
   selectedBooks.value = []; // Reset selection on fetch
   try {
-    const response = await api.get('/books');
+    const response = await api.get('/admin/books');
     books.value = response.data || response;
   } catch (err) {
     console.error("Failed to fetch books:", err);

--- a/app/pages/book/[slug].vue
+++ b/app/pages/book/[slug].vue
@@ -96,11 +96,13 @@
 import { ref, computed, watch } from 'vue';
 import { useAuthStore } from '~/stores/auth';
 import { usePurchaseStore } from '~/stores/purchase';
+import { useApiAuth } from '~/composables/useApiAuth';
 
 const route = useRoute();
 const slug = route.params.slug;
 const authStore = useAuthStore();
 const purchaseStore = usePurchaseStore();
+const api = useApiAuth();
 
 // State for the component
 const book = ref(null);
@@ -119,9 +121,7 @@ async function fetchBook() {
   error.value = null;
   debugInfo.value = null;
   try {
-    const response = await $fetch(`http://localhost:8000/api/v1/book/${slug}`, {
-      headers: { 'Authorization': `Bearer ${authStore.token}`, 'Accept': 'application/json' }
-    });
+    const response = await api.get(`/book/${slug}`);
 
     debugInfo.value = {
       timestamp: new Date().toISOString(),
@@ -175,10 +175,7 @@ async function processPurchase() {
   notification.value = { show: false, message: '', type: 'success' };
 
   try {
-    const response = await $fetch(`http://localhost:8000/api/v1/books/${slug}/buy`, {
-      method: 'POST',
-      headers: { 'Authorization': `Bearer ${authStore.token}`, 'Accept': 'application/json' }
-    });
+    const response = await api.post(`/book/${slug}/buy`);
     // On success, show a notification and refetch the book data to update the state.
     notification.value = { show: true, message: response.message || 'خرید با موفقیت انجام شد!', type: 'success' };
     purchaseStore.clearPurchases(); // Invalidate the purchases list


### PR DESCRIPTION
This commit addresses several issues to ensure book data is displayed correctly.

- In `app/pages/admin/books.vue`, the API call is corrected to use the `/admin/books` endpoint, ensuring all books are fetched for the admin panel.
- In `app/pages/book/[slug].vue`, hardcoded `$fetch` calls are refactored to use the `useApiAuth` composable. This standardizes API calls and removes hardcoded URLs.
- The purchase endpoint in `book/[slug].vue` is corrected from `/books/{slug}/buy` to `/book/{slug}/buy` for consistency.