### PR TITLE
feat: Implement book merge logic in frontend

### DIFF
--- a/app/components/BookCard.vue
+++ b/app/components/BookCard.vue
@@ -16,6 +16,14 @@
         <h3 class="font-semibold text-gray-800 mb-1 line-clamp-1 hover:text-blue-600">{{ book.title }}</h3>
       </NuxtLink>
       <p class="text-sm text-gray-600 mb-2">{{ book.authors && book.authors.length > 0 ? book.authors[0].name : 'ناشناس' }}</p>
+
+      <!-- Master Book Formats -->
+      <div v-if="book.is_master && book.variants_data && book.variants_data.formats" class="mb-2">
+        <span v-for="format in book.variants_data.formats" :key="format" class="inline-block bg-gray-200 rounded-full px-2 py-1 text-xs font-semibold text-gray-700 mr-1">
+          {{ format.toUpperCase() }}
+        </span>
+      </div>
+
       <div class="mt-auto">
         <!-- Download Links Section -->
         <div v-if="showDownloadLinks" class="pt-4 border-t mt-4">


### PR DESCRIPTION
Implements the frontend functionality for the Book Merge feature based on the provided API documentation.

- Updates the Book Detail page (`book/[slug].vue`) to display aggregated data (formats, publication years) for master books.
- Adds a comprehensive download section on the book detail page for purchased master books, listing all available files from the master and its variants.
- Enhances the `BookCard` component to show available formats for master books on the main store page.
- Modifies the "My Purchases" page (`my-purchases.vue`) to display download links for all parts of a merged book set (master + variants).