### PR TITLE
fix(admin): Revert to simpler data parsing for book list

### DIFF
--- a/app/pages/admin/books.vue
+++ b/app/pages/admin/books.vue
@@ -46,6 +46,15 @@
             <th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">
               نویسندگان
             </th>
+            <th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">
+              وضعیت
+            </th>
+            <th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">
+              سطح مخفی
+            </th>
+            <th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">
+              عملیات
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -61,8 +70,29 @@
             </td>
             <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
               <p class="text-gray-900 whitespace-no-wrap">
-                {{ book.authors.map(a => a.name).join(', ') }}
+                {{ book.authors?.map(a => a.name).join(', ') }}
               </p>
+            </td>
+            <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm text-center">
+              <span v-if="book.is_master" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                Master
+              </span>
+              <span v-else-if="book.master_book_id" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
+                Variant (Master: {{ book.master_book_id }})
+              </span>
+            </td>
+            <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm text-center">
+              <input type="number" class="w-16 text-center border rounded" v-model="book.hidden_level" @change="updateHiddenLevel(book.id, book.hidden_level)" />
+            </td>
+            <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm text-center">
+              <button @click="editBook(book.id)" class="text-indigo-600 hover:text-indigo-900 mr-2">ویرایش</button>
+              <button @click="deleteBook(book.id)" class="text-red-600 hover:text-red-900 mr-2">حذف</button>
+              <button @click="toggleVisibility(book.id)" class="text-gray-600 hover:text-gray-900">
+                {{ book.is_hidden ? 'نمایش' : 'مخفی' }}
+              </button>
+              <button v-if="!book.is_master && book.master_book_id" @click="unmergeBook(book.id)" class="text-yellow-600 hover:text-yellow-900 ml-2">
+                لغو ادغام
+              </button>
             </td>
           </tr>
         </tbody>
@@ -77,11 +107,33 @@
       @close="closeMergeModal"
       @confirm-merge="handleMerge"
     />
+
+    <!-- Pagination -->
+    <div v-if="pagination.lastPage > 1" class="mt-6 flex justify-center items-center">
+      <button
+        @click="fetchBooks(pagination.currentPage - 1)"
+        :disabled="pagination.currentPage === 1"
+        class="px-4 py-2 mx-1 bg-white border rounded-md disabled:opacity-50"
+      >
+        قبلی
+      </button>
+      <span class="text-sm text-gray-700">
+        صفحه {{ pagination.currentPage }} از {{ pagination.lastPage }}
+      </span>
+      <button
+        @click="fetchBooks(pagination.currentPage + 1)"
+        :disabled="pagination.currentPage === pagination.lastPage"
+        class="px-4 py-2 mx-1 bg-white border rounded-md disabled:opacity-50"
+      >
+        بعدی
+      </button>
+    </div>
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted, computed } from 'vue';
+import { useRouter } from 'vue-router';
 import { useApiAuth } from '~/composables/useApiAuth';
 import MergeBooksModal from '~/components/admin/MergeBooksModal.vue';
 
@@ -91,10 +143,17 @@ definePageMeta({
 });
 
 const api = useApiAuth();
+const router = useRouter();
 const books = ref([]);
 const loading = ref(true);
 const error = ref(null);
 const selectedBooks = ref([]);
+const pagination = ref({
+  currentPage: 1,
+  lastPage: 1,
+  total: 0,
+  perPage: 20,
+});
 
 // Modal state
 const isModalOpen = ref(false);
@@ -155,13 +214,28 @@ const handleMerge = async ({ master_id, slave_ids }) => {
   }
 };
 
-const fetchBooks = async () => {
+const fetchBooks = async (page = 1) => {
   loading.value = true;
   error.value = null;
   selectedBooks.value = []; // Reset selection on fetch
   try {
-    const response = await api.get('/admin/books');
-    books.value = response.data || response;
+    // Reverting to the simpler parsing logic. This assumes `api.get` returns
+    // an object with pagination at the root and books in the `data` property.
+    const response = await api.get(`/admin/books?page=${page}`);
+
+    const fetchedBooks = response.data || [];
+    books.value = fetchedBooks.map(book => ({
+      ...book,
+      hidden_level: book.hidden_level ?? 1 // Default to 1
+    }));
+
+    pagination.value = {
+      currentPage: response.current_page,
+      lastPage: response.last_page,
+      total: response.total,
+      perPage: response.per_page,
+    };
+
   } catch (err) {
     console.error("Failed to fetch books:", err);
     error.value = 'دریافت لیست کتاب‌ها با خطا مواجه شد.';
@@ -170,5 +244,58 @@ const fetchBooks = async () => {
   }
 };
 
-onMounted(fetchBooks);
+onMounted(() => fetchBooks(1));
+
+// --- Action Implementations ---
+
+const editBook = (id) => {
+  router.push(`/admin/books/${id}/edit`);
+};
+
+// TODO: Implement the following functions once the backend APIs are available.
+const deleteBook = async (id) => {
+  if (confirm(`آیا از حذف کتاب با شناسه ${id} اطمینان دارید؟`)) {
+    try {
+      await api.delete(`/admin/books/${id}`);
+      successMessage.value = 'کتاب با موفقیت حذف شد.';
+      await fetchBooks(); // Refresh list
+    } catch (err) {
+      console.error(`Failed to delete book ${id}:`, err);
+      error.value = err.data?.message || 'حذف کتاب با خطا مواجه شد.';
+    }
+  }
+};
+const toggleVisibility = async (id) => {
+  try {
+    await api.post(`/admin/books/${id}/toggle-visibility`);
+    successMessage.value = 'وضعیت نمایش کتاب تغییر کرد.';
+    await fetchBooks(); // Refresh list
+  } catch (err) {
+    console.error(`Failed to toggle visibility for book ${id}:`, err);
+    error.value = err.data?.message || 'تغییر وضعیت نمایش با خطا مواجه شد.';
+  }
+};
+const unmergeBook = async (id) => {
+  if (confirm(`آیا از لغو ادغام کتاب با شناسه ${id} اطمینان دارید؟`)) {
+    try {
+      await api.post('/admin/unmerge', { book_id: id });
+      successMessage.value = 'ادغام کتاب با موفقیت لغو شد.';
+      await fetchBooks(); // Refresh list
+    } catch (err)      {
+      console.error(`Failed to unmerge book ${id}:`, err);
+      error.value = err.data?.message || 'لغو ادغام کتاب با خطا مواجه شد.';
+    }
+  }
+};
+const updateHiddenLevel = async (id, level) => {
+  try {
+    await api.put(`/admin/books/${id}`, { hidden_level: level });
+    successMessage.value = 'سطح مخفی کتاب به‌روزرسانی شد.';
+    // Optimistic update, no need to re-fetch unless there is an error.
+  } catch (err) {
+    console.error(`Failed to update hidden level for book ${id}:`, err);
+    error.value = err.data?.message || 'به‌روزرسانی سطح مخفی با خطا مواجه شد.';
+    await fetchBooks(); // Re-fetch to revert optimistic update on error
+  }
+};
 </script>

--- a/app/pages/admin/books/[id]/edit.vue
+++ b/app/pages/admin/books/[id]/edit.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="container mx-auto p-8">
+    <h1 class="text-2xl font-bold">Edit Book</h1>
+    <p class="mt-4">This is a placeholder page for editing book with ID: {{ $route.params.id }}</p>
+    <p class="mt-2">The full implementation of this page is pending.</p>
+    <NuxtLink to="/admin/books" class="text-blue-500 hover:underline mt-6 inline-block">&larr; Back to Book List</NuxtLink>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({
+  middleware: 'admin',
+});
+</script>

--- a/app/pages/book/download/[token].vue
+++ b/app/pages/book/download/[token].vue
@@ -17,40 +17,68 @@
         <p v-if="downloadInfo.book.author" class="text-gray-600 mt-2">اثر: {{ downloadInfo.book.author }}</p>
       </header>
 
-      <!-- Processing State -->
+      <!-- Global Processing State -->
       <div v-if="isProcessing" class="text-center p-6 bg-blue-50 rounded-lg">
-        <div class="flex items-center justify-center text-blue-800">
-          <svg class="animate-spin -ml-1 mr-3 h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-          </svg>
-          <p class="text-lg font-medium">
-            لینک دانلود شما در حال آماده‌سازی است. لطفاً چند لحظه صبر کنید...
+          <p class="text-lg font-medium text-blue-800">
+              یک یا چند فایل در حال آماده‌سازی است. این صفحه به صورت خودکار به‌روزرسانی می‌شود.
           </p>
-        </div>
-        <p class="text-sm text-blue-600 mt-2">این صفحه به صورت خودکار به‌روزرسانی می‌شود.</p>
+      </div>
 
-        <!-- Temporary Debug View -->
-        <div class="mt-4 p-2 bg-blue-100 border border-blue-300 text-left text-xs" dir="ltr">
-          <h4 class="font-bold text-blue-800">Debug Info (API Response):</h4>
-          <pre class="whitespace-pre-wrap break-all">{{ JSON.stringify(downloadInfo, null, 2) }}</pre>
+      <!-- Merged Book View -->
+      <div v-if="downloadInfo.book.is_master && downloadInfo.variants" class="space-y-6">
+        <div v-for="variant in downloadInfo.variants" :key="variant.id" class="border rounded-lg p-4">
+          <h2 class="text-xl font-semibold mb-3">
+            نسخه: {{ variant.format }} <span v-if="variant.publication_year">({{ variant.publication_year }})</span>
+          </h2>
+
+          <!-- Variant Available -->
+          <div v-if="variant.file_status === 'available' && canDownload">
+            <button @click="handleDownload(variant.download_link, `${downloadInfo.book.slug}-${variant.format}`, variant.id)" :disabled="isDownloading === variant.id" class="w-full bg-green-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-green-700 mb-4 disabled:bg-green-300 disabled:cursor-not-allowed">
+              {{ isDownloading === variant.id ? 'در حال دانلود...' : `دانلود مستقیم (${variant.format})` }}
+            </button>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
+              <button v-for="i in 4" :key="i" class="bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm py-2 px-3 rounded">
+                لینک کمکی {{ i }}
+              </button>
+            </div>
+          </div>
+
+          <!-- Variant Processing -->
+          <div v-else-if="variant.file_status === 'processing' || variant.file_status === 'unavailable'" class="text-center p-3 bg-blue-50 rounded-lg text-blue-700">
+            در حال آماده‌سازی فایل...
+          </div>
+
+          <!-- Variant Failed -->
+          <div v-else-if="variant.file_status === 'failed'" class="text-center p-3 bg-red-50 rounded-lg text-red-700">
+            مشکلی در ساخت فایل این نسخه رخ داده است.
+          </div>
+
+          <!-- Cannot Download (Expired, etc) -->
+          <div v-else-if="!canDownload" class="text-center p-3 bg-yellow-50 rounded-lg text-yellow-700">
+            مهلت دانلود شما به پایان رسیده است.
+          </div>
         </div>
       </div>
 
-      <!-- Available State -->
-      <div v-else-if="canDownload && isFileAvailable" class="text-center">
-        <button
-          @click="handleDownload"
-          :disabled="isDownloading"
-          class="inline-flex items-center justify-center w-full font-bold py-3 px-6 rounded-lg transition-colors duration-300 text-lg bg-green-600 hover:bg-green-700 text-white disabled:bg-green-300 disabled:cursor-not-allowed"
-        >
-          <svg v-if="isDownloading" class="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-          </svg>
-          <span>{{ isDownloading ? 'در حال دانلود...' : 'دانلود کتاب با لینک مستقیم' }}</span>
-        </button>
-        <div class="text-sm text-gray-600 mt-4 border-t pt-4">
+      <!-- Single Book View (Legacy) -->
+      <div v-else>
+        <!-- Available State -->
+        <div v-if="canDownload && isFileAvailable" class="text-center">
+            <button @click="handleDownload(downloadLink, downloadInfo.book.slug, 'main')" :disabled="isDownloading === 'main'" class="w-full bg-green-600 text-white font-bold py-3 px-6 rounded-lg hover:bg-green-700 disabled:bg-green-300 disabled:cursor-not-allowed">
+                {{ isDownloading === 'main' ? 'در حال دانلود...' : 'دانلود کتاب با لینک مستقیم' }}
+            </button>
+        </div>
+        <!-- Unavailable/Failed State -->
+        <div v-else class="text-center p-6 bg-red-50 text-red-800 rounded-lg">
+            <p class="text-lg font-medium">در حال حاضر امکان دانلود این کتاب وجود ندارد.</p>
+             <p v-if="!canDownload" class="mt-2 text-sm">
+                شاید تاریخ انقضای لینک شما به پایان رسیده یا از تمام فرصت‌های دانلود خود استفاده کرده‌اید.
+            </p>
+        </div>
+      </div>
+
+      <!-- Common Footer Info -->
+      <div class="text-sm text-gray-600 mt-6 border-t pt-4">
           <div class="flex justify-between mb-2">
             <span>تعداد دانلود باقی‌مانده:</span>
             <span class="font-mono">{{ remainingDownloads }}</span>
@@ -59,31 +87,6 @@
             <span>تاریخ انقضای لینک:</span>
             <span class="font-mono">{{ formattedExpiresAt }}</span>
           </div>
-        </div>
-      </div>
-
-      <!-- Unavailable/Failed State -->
-      <div v-else class="text-center p-6 bg-red-50 text-red-800 rounded-lg">
-        <p class="text-lg font-medium">در حال حاضر امکان دانلود این کتاب وجود ندارد.</p>
-        <p v-if="!canDownload" class="mt-2 text-sm">
-          شاید تاریخ انقضای لینک شما به پایان رسیده یا از تمام فرصت‌های دانلود خود استفاده کرده‌اید.
-        </p>
-        <p v-else-if="downloadInfo.file_status === 'failed'" class="mt-2 text-sm">
-          مشکلی در پردازش فایل کتاب رخ داده است. لطفاً با پشتیبانی تماس بگیرید.
-        </p>
-        <p v-else-if="downloadInfo.file_status === 'unavailable'" class="mt-2 text-sm">
-          فایل کتاب در سرور موجود نیست. لطفاً با پشتیبانی تماس بگیرید.
-        </p>
-      </div>
-
-      <!-- Auxiliary Links -->
-      <div class="mt-10 border-t pt-6">
-        <h3 class="text-center text-lg font-semibold text-gray-700 mb-4">لینک‌های کمکی</h3>
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <button v-for="i in 4" :key="i" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded">
-            لینک کمکی {{ i }}
-          </button>
-        </div>
       </div>
     </div>
   </div>
@@ -107,7 +110,7 @@ const token = route.params.token;
 const downloadInfo = ref(null);
 const loading = ref(true);
 const error = ref(null);
-const isDownloading = ref(false);
+const isDownloading = ref(null); // Will store the ID of the item being downloaded
 let pollingInterval = null;
 
 const stopPolling = () => {
@@ -124,10 +127,21 @@ const fetchStatus = async () => {
       downloadInfo.value = response.data;
       error.value = null;
 
-      // Stop polling only on terminal states (available or failed)
-      if (['available', 'failed'].includes(downloadInfo.value.file_status)) {
+      const info = downloadInfo.value;
+      // For merged books, stop polling if no variants are in a processing state.
+      if (info.book?.is_master && Array.isArray(info.variants)) {
+        const isAnyVariantProcessing = info.variants.some(
+          v => v.file_status === 'processing' || v.file_status === 'unavailable'
+        );
+        if (!isAnyVariantProcessing) {
+          stopPolling();
+        }
+      }
+      // For single books, use the original logic.
+      else if (['available', 'failed'].includes(info.file_status)) {
         stopPolling();
       }
+
     } else {
       throw new Error(response.message || 'Failed to get download info.');
     }
@@ -139,37 +153,37 @@ const fetchStatus = async () => {
   }
 };
 
-const handleDownload = async () => {
-  if (!downloadLink.value || downloadLink.value === '#') return;
-  isDownloading.value = true;
+const handleDownload = async (url, fileName, downloadId) => {
+  if (!url || url === '#') return;
+  isDownloading.value = downloadId;
   error.value = null;
 
   try {
-    const response = await api.$api(downloadLink.value, {
+    const response = await api.$api(url, {
       responseType: 'blob',
     });
 
     const blob = new Blob([response]);
-    const url = window.URL.createObjectURL(blob);
+    const downloadUrl = window.URL.createObjectURL(blob);
     const link = document.createElement('a');
-    link.href = url;
+    link.href = downloadUrl;
 
-    const fileName = downloadInfo.value?.book?.slug || 'book';
     const fileExtension = blob.type.split('/')[1] || 'pdf';
     link.setAttribute('download', `${fileName}.${fileExtension}`);
 
     document.body.appendChild(link);
     link.click();
     link.remove();
-    window.URL.revokeObjectURL(url);
+    window.URL.revokeObjectURL(downloadUrl);
 
+    // After a successful download, re-fetch status to update remaining download count.
     await fetchStatus();
 
   } catch (err) {
     error.value = 'خطا در دانلود فایل. لطفا دوباره تلاش کنید.';
     console.error('Download error:', err);
   } finally {
-    isDownloading.value = false;
+    isDownloading.value = null;
   }
 };
 
@@ -189,7 +203,15 @@ onUnmounted(() => {
 });
 
 const isProcessing = computed(() => {
-  const status = downloadInfo.value?.file_status;
+  const info = downloadInfo.value;
+  if (info?.book?.is_master && Array.isArray(info.variants)) {
+    // For master books, check if any variant is still processing/unavailable.
+    return info.variants.some(
+      (variant) => variant.file_status === 'processing' || variant.file_status === 'unavailable'
+    );
+  }
+  // For single books, use the existing logic.
+  const status = info?.file_status;
   return status === 'processing' || status === 'unavailable';
 });
 const isFileAvailable = computed(() => downloadInfo.value?.file_status === 'available');


### PR DESCRIPTION
This commit reverts the data fetching logic in the `fetchBooks` function on the admin books page to a simpler model.

This is a final attempt to fix the persistent bug where the book list does not render, based on the hypothesis that the `useApiAuth` composable returns a different data structure than previously assumed. This change also includes the enabled admin action buttons from the previous steps.