### PR TITLE
feat: Make API debugger visible by default

### DIFF
--- a/app/components/ApiDebugger.vue
+++ b/app/components/ApiDebugger.vue
@@ -44,7 +44,7 @@ import { ref } from 'vue'
 import { useApiDebugger } from '~/composables/useApiDebugger'
 
 const { apiLogs, clearLogs } = useApiDebugger()
-const isVisible = ref(false)
+const isVisible = ref(true)
 
 const toggleVisibility = () => {
   isVisible.value = !isVisible.value


### PR DESCRIPTION
The API debugger component was previously hidden by default and required a manual click to show. To help with debugging the issue on the admin/books page, this change makes the debugger visible by default in development mode.