### PR TITLE
fix: Use authenticated API client on roles page

### DIFF
--- a/app/pages/admin/roles.vue
+++ b/app/pages/admin/roles.vue
@@ -68,7 +68,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
-import { useApi } from '~/composables/useApi';
+import { useApiAuth } from '~/composables/useApiAuth';
 import type { Role, Permission, CreateRolePayload, UpdateRolePayload } from '~/types/auth';
 import RoleModal from '~/components/admin/RoleModal.vue';
 
@@ -77,7 +77,7 @@ definePageMeta({
   middleware: ['auth'],
 });
 
-const api = useApi();
+const api = useApiAuth();
 
 const roles = ref<Role[]>([]);
 const groupedPermissions = ref<Record<string, Permission[]>>({});


### PR DESCRIPTION
The admin roles page was using the public API client (`useApi`), which does not send authentication headers. This caused a 401 Unauthorized error when the page tried to fetch the list of permissions.

This commit resolves the issue by switching to the `useApiAuth` composable, which is designed for authenticated requests and correctly includes the user's auth token.