### PR TITLE
fix: Correct API endpoint for book visibility

### DIFF
--- a/app/pages/admin/books.vue
+++ b/app/pages/admin/books.vue
@@ -330,7 +330,7 @@ const deleteBook = async (id) => {
 
 const setBookHiddenLevel = async (book, level) => {
   try {
-    await api.post(`/admin/books/${book.id}/hide`, { level });
+    await api.post(`/admin/books/${book.id}/toggle-visibility`, { level });
     successMessage.value = 'وضعیت نمایش کتاب تغییر کرد.';
     await fetchBooks(); // Refresh list
   } catch (err) {


### PR DESCRIPTION
This commit corrects the API endpoint used for toggling the visibility of a book. The endpoint was previously changed to `/hide`, which resulted in a 404 error as the route does not exist on the backend.

The endpoint has been reverted to the original `/toggle-visibility`, which is the correct route. The implementation now sends the hidden `level` in the request body to this endpoint, allowing the backend to manage the multi-level visibility state.