### PR TITLE
Fix: Optimistically update book visibility status

### DIFF
--- a/app/pages/admin/books/index.vue
+++ b/app/pages/admin/books/index.vue
@@ -349,14 +349,18 @@ const setBookHiddenLevel = async (book, level) => {
     await api.post(`/admin/books/${book.id}/toggle-visibility`, { level });
     successMessage.value = 'وضعیت نمایش کتاب تغییر کرد.';
 
+    // Optimistically update the book's state
+    book.is_hidden = level;
+
     // Then, if the book was auto-blocked, update its filter status to manual
     if (book.content_filter_status === 'auto_blocked') {
       const newStatus = level > 0 ? 'manually_blocked' : 'manually_approved';
       await api.post(`/admin/books/${book.id}/content-filter-status`, { status: newStatus });
       successMessage.value += ' وضعیت فیلتر به دستی تغییر یافت.';
+      // Optimistically update the status
+      book.content_filter_status = newStatus;
     }
 
-    await fetchBooks(); // Refresh list
   } catch (err) {
     console.error(`Failed to set hidden level for book ${book.id}:`, err);
     const errorMessage = err.data?.message || 'تغییر وضعیت نمایش با خطا مواجه شد.';


### PR DESCRIPTION
When clicking the 'Hide' or 'Show' button on the admin books page, the UI did not update to reflect the new status, although the API call was successful. This was because the component was re-fetching the entire list of books, which might have been returning a cached or otherwise outdated response.

This commit fixes the issue by implementing an optimistic UI update. Instead of re-fetching the book list, the local state of the book is updated directly after the API call succeeds. This provides an immediate visual response and improves performance by removing an unnecessary network request.