### PR TITLE
chore: Replace icon with text for debugging

### DIFF
--- a/app/pages/admin/books/index.vue
+++ b/app/pages/admin/books/index.vue
@@ -124,7 +124,7 @@
                     class="inline-flex items-center"
                     :class="book.override ? 'text-green-500' : 'text-red-500'"
                     title="وضعیت این کتاب توسط مدیر تثبیت شده و تحت تاثیر فیلتر خودکار قرار نمی‌گیرد.">
-                    <span class="w-4 h-4 i-heroicons-lock-closed-solid"></span>
+                    <span>[LOCK]</span>
                   </span>
                 </div>
                 <div class="flex flex-col items-center gap-2">


### PR DESCRIPTION
This commit replaces the lock icon with the text `[LOCK]` to determine if the issue is with the icon library or the rendering of the component itself.

This is a temporary commit for debugging and will be reverted.