### PR TITLE
fix: Correct gallery page URL and naming

### DIFF
--- a/app/layouts/admin.vue
+++ b/app/layouts/admin.vue
@@ -33,9 +33,9 @@
             </NuxtLink>
           </li>
           <li>
-            <NuxtLink to="/admin/book-images" class="flex items-center gap-3 px-4 py-2 rounded hover:bg-gray-700" active-class="bg-gray-900">
+            <NuxtLink to="/admin/gallery" class="flex items-center gap-3 px-4 py-2 rounded hover:bg-gray-700" active-class="bg-gray-900">
               <span class="w-6 h-6 i-heroicons-photo-solid"></span>
-              <span>بازبینی تصاویر کتاب</span>
+              <span>گالری تصاویر کتاب ها</span>
             </NuxtLink>
           </li>
           <li>

--- a/app/pages/admin/gallery/index.vue
+++ b/app/pages/admin/gallery/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-semibold">بازبینی تصاویر کتاب‌ها</h1>
+      <h1 class="text-2xl font-semibold">گالری تصاویر کتاب ها</h1>
       <div v-if="!loading" class="text-gray-600">
         <span class="font-medium">{{ pendingCount }}</span> تصویر در انتظار،
         <span class="font-medium text-green-600">{{ approvedCount }}</span> تایید شده،
@@ -101,7 +101,7 @@ import { useApiAuth } from '~/composables/useApiAuth'
 
 definePageMeta({
   layout: 'admin',
-  title: 'بازبینی تصاویر کتاب',
+  title: 'گالری تصاویر کتاب ها',
   middleware: 'admin'
 })
 


### PR DESCRIPTION
This commit fixes a 404 error for the book image review page. The page was previously created at `/admin/book-images`, but the user expected it at `/admin/gallery`.

Changes:
- Renamed the page directory from `app/pages/admin/book-images` to `app/pages/admin/gallery`.
- Updated the link in the admin layout to point to `/admin/gallery`.
- Updated the link text and page titles to "گالری تصاویر کتاب ها" to match the user's terminology.