### PR TITLE
This commit introduces two major features related to book images:

### DIFF
--- a/app/pages/admin/gallery/index.vue
+++ b/app/pages/admin/gallery/index.vue
@@ -198,17 +198,20 @@ async function submitReviews() {
   const images_to_approve = []
   const images_to_reject = []
 
+  // Process all images currently loaded on the page
   for (const id in reviewStates.value) {
     const state = reviewStates.value[id];
-    if (state.status === 'approved') {
+    // Treat 'pending' as 'approved' during final submission
+    if (state.status === 'approved' || state.status === 'pending') {
       images_to_approve.push(parseInt(id, 10))
     } else if (state.status === 'rejected') {
       images_to_reject.push({ id: parseInt(id, 10), rejection_reason: state.reason })
     }
   }
 
+  // Do not submit if no action is to be taken (e.g., all images were left pending and are now being approved)
   if (images_to_approve.length === 0 && images_to_reject.length === 0) {
-    alert("هیچ تغییری برای ثبت وجود ندارد.");
+    alert("هیچ تصویری برای بررسی وجود ندارد.");
     submitting.value = false;
     return;
   }
@@ -232,6 +235,7 @@ async function submitReviews() {
         alert(response.message || 'عملیات با موفقیت انجام شد.');
     }
 
+    // Refresh the list of images
     await fetchImages()
 
   } catch (err) {


### PR DESCRIPTION
1.  **Admin Image Review Gallery (`/admin/gallery`):**
    *   A new page in the admin panel for reviewing and moderating user-uploaded book images.
    *   Admins can view pending images, approve or reject them individually, and provide a reason for rejection.
    *   Includes a "Submit Changes" button that processes all on-screen images in a single bulk API call, approving any that were left pending.

2.  **Public Book Page Gallery (`/book/{slug}`):**
    *   The book detail page now displays a gallery of all approved images for that book.
    *   Features a main image display with clickable thumbnails below it to switch between images.
    *   Fetches images from a public, non-authenticated API endpoint.

This commit also includes fixes for the admin gallery submission logic and improvements to Vue keys for better stability.