### PR TITLE
feat: نمایش تصاویر تایید شده کتاب

### DIFF
--- a/app/components/BookCard.vue
+++ b/app/components/BookCard.vue
@@ -84,12 +84,9 @@ const formatPrice = (price) => {
 };
 
 const imageUrl = computed(() => {
-  // The logic is to show the image only if it exists and is approved.
-  // Otherwise, fall back to a placeholder.
   if (props.book.image && props.book.image.thumbnail_url && props.book.image.status === 'approved') {
     return props.book.image.thumbnail_url;
   }
-  // This is a generic placeholder. You might want to create one that matches your site's design.
   return '/images/placeholders/book-placeholder-thumb.jpg';
 });
 </script>


### PR DESCRIPTION
- تصاویر کتاب در لیست کتاب‌ها و صفحه تک کتاب فقط در صورتی نمایش داده می‌شوند که وضعیت آن‌ها 'approved' باشد.
- این کار با افزودن منطق شرطی در کامپوننت‌های Vue برای بررسی وضعیت تصویر قبل از رندر کردن انجام شده است.