### PR TITLE
Fix(frontend): Correctly display book cover images

### DIFF
--- a/app/components/BookCard.vue
+++ b/app/components/BookCard.vue
@@ -3,7 +3,7 @@
     <NuxtLink :to="`/book/${book.slug}`" class="block">
       <div class="relative">
         <img :src="imageUrl"
-             :alt="book.title"
+             :alt="book.image && book.image.alt_text ? book.image.alt_text : book.title"
              class="w-full h-48 object-cover rounded-t-lg">
         <div v-if="book.discount_percent"
              class="absolute top-2 left-2 bg-red-500 text-white px-2 py-1 rounded text-xs">
@@ -84,9 +84,12 @@ const formatPrice = (price) => {
 };
 
 const imageUrl = computed(() => {
-  if (props.book.image && props.book.image.thumbnail_url && props.book.image.status === 'approved') {
-    return props.book.image.thumbnail_url;
+  if (props.book.image) {
+    // First, try thumbnail_url, then fall back to the main url.
+    // This handles both real images and placeholder images from the API.
+    return props.book.image.thumbnail_url || props.book.image.url;
   }
+  // If for some reason the book has no image object at all, return a static placeholder.
   return '/images/placeholders/book-placeholder-thumb.jpg';
 });
 </script>


### PR DESCRIPTION
This commit resolves an issue in the `BookCard.vue` component where book cover images were not being displayed correctly.

The `imageUrl` computed property was previously checking for a `status` field on the image object which does not exist in the API response, causing it to always fall back to a local placeholder.

The logic has been updated to:
- Prioritize `book.image.thumbnail_url` for display.
- Fall back to `book.image.url` if the thumbnail is not available.
- This handles both real images and placeholder images provided by the API.

Additionally, the `alt` attribute of the `<img>` tag has been updated to use the `book.image.alt_text` field for better accessibility and SEO, with a fallback to the book's title.