### PR TITLE
Refactor(frontend): Add status check for book image display

### DIFF
--- a/app/components/BookCard.vue
+++ b/app/components/BookCard.vue
@@ -84,12 +84,12 @@ const formatPrice = (price) => {
 };
 
 const imageUrl = computed(() => {
-  if (props.book.image) {
-    // First, try thumbnail_url, then fall back to the main url.
-    // This handles both real images and placeholder images from the API.
+  // Only show the image if it exists and its status is 'approved'.
+  if (props.book.image && props.book.image.status === 'approved') {
+    // Prioritize thumbnail_url, but fall back to the main url.
     return props.book.image.thumbnail_url || props.book.image.url;
   }
-  // If for some reason the book has no image object at all, return a static placeholder.
+  // For any other status (e.g., pending, rejected) or if there's no image, show the placeholder.
   return '/images/placeholders/book-placeholder-thumb.jpg';
 });
 </script>


### PR DESCRIPTION
This commit updates the `BookCard.vue` component to only display images for books that have an 'approved' status.

Based on user feedback, the previous implementation showed images for all books, regardless of their status. This change re-introduces a status check in the `imageUrl` computed property.

The logic now ensures that:
- Images are only shown if `book.image.status` is 'approved'.
- For all other statuses (e.g., 'pending', 'rejected') or if no image is present, a placeholder is displayed.