### PR TITLE
fix(gallery): update admin gallery API endpoints

### DIFF
--- a/app/pages/admin/gallery/index.vue
+++ b/app/pages/admin/gallery/index.vue
@@ -133,7 +133,7 @@ async function fetchImages() {
   loading.value = true
   error.value = null
   try {
-    const response = await api.get('/book-images', {
+    const response = await api.get('/book/all/images', {
       params: { status: 'pending', per_page: 100 }
     })
     images.value = response.data?.data || []
@@ -219,7 +219,7 @@ async function submitReviews() {
   const payload = { images_to_approve, images_to_reject }
 
   try {
-    const response = await api.patch('/book-images/review-bulk', payload)
+    const response = await api.patch('/book/images/review-bulk', payload)
 
     if (response.data?.failed_count > 0) {
         let alertMessage = `عملیات با موفقیت نسبی انجام شد.\n` +


### PR DESCRIPTION
The admin gallery page was failing to load images due to a 500 Internal Server Error. This was caused by incorrect API endpoints being used for fetching and reviewing images.

This commit updates the endpoints in `app/pages/admin/gallery/index.vue` to align with the correct API structure:
- Fetches images from `GET /api/v1/book/all/images`.
- Submits reviews to `PATCH /api/v1/book/images/review-bulk`.