### PR TITLE
fix(gallery): remove status parameter from image fetch

### DIFF
--- a/app/pages/admin/gallery/index.vue
+++ b/app/pages/admin/gallery/index.vue
@@ -133,8 +133,8 @@ async function fetchImages() {
   loading.value = true
   error.value = null
   try {
-    const response = await api.get('/book/all/images', {
-      params: { status: 'pending', per_page: 100 }
+    const response = await api.get('/book-images', {
+      params: { per_page: 100 }
     })
     images.value = response.data?.data || []
     initializeStates()
@@ -219,7 +219,7 @@ async function submitReviews() {
   const payload = { images_to_approve, images_to_reject }
 
   try {
-    const response = await api.patch('/book/images/review-bulk', payload)
+    const response = await api.patch('/book-images/review-bulk', payload)
 
     if (response.data?.failed_count > 0) {
         let alertMessage = `عملیات با موفقیت نسبی انجام شد.\n` +


### PR DESCRIPTION
The admin gallery was failing with a 500 error when fetching images with the `status: 'pending'` parameter. This suggests a backend issue with filtering by status.

This commit removes the `status` parameter from the `fetchImages` API call in `app/pages/admin/gallery/index.vue`. The component will now fetch all images and handle their status on the client side, which avoids the backend error and allows the page to load correctly.