### PR TITLE
fix(gallery): Correctly parse image data from API response

### DIFF
--- a/app/pages/admin/gallery/index.vue
+++ b/app/pages/admin/gallery/index.vue
@@ -136,7 +136,7 @@ async function fetchImages() {
     const response = await api.get('/book-images', {
       params: { status: 'pending', per_page: 100 }
     })
-    images.value = response.data?.data || []
+    images.value = response.data || []
     initializeStates()
   } catch (err) {
     console.error('Error fetching images:', err)


### PR DESCRIPTION
After a backend fix, the admin gallery API is correctly returning a list of images. However, the frontend was failing to display them due to an incorrect data access path.

The API returns the image array in `response.data`, but the code was attempting to access `response.data.data`.

This commit corrects the data access path in the `fetchImages` function in `app/pages/admin/gallery/index.vue`, allowing the frontend to correctly parse the response and display the images for review.