### PR TITLE
feat: add pagination options to book sync

### DIFF
--- a/app/pages/admin/fetch-books.vue
+++ b/app/pages/admin/fetch-books.vue
@@ -8,12 +8,46 @@
       </div>
 
       <!-- Sync Control Panel -->
-      <div class="bg-white p-6 rounded-lg shadow">
-        <div class="flex items-center justify-between">
+      <div class="bg-white p-6 rounded-lg shadow space-y-6">
+        <div>
+          <h2 class="text-lg font-medium text-gray-900">شروع همگام‌سازی</h2>
+          <p class="text-sm text-gray-500 mt-1">
+            فرآیند دریافت و همگام‌سازی کتاب‌ها از منبع خارجی را آغاز کنید. می‌توانید همه کتاب‌ها را همگام‌سازی کنید یا محدوده مشخصی را تعیین کنید.
+          </p>
+        </div>
+
+        <!-- Pagination Options -->
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 border-t border-gray-200 pt-6">
+          <!-- Sync Single Page -->
           <div>
-            <h2 class="text-lg font-medium text-gray-900">شروع همگام‌سازی</h2>
-            <p class="text-sm text-gray-500 mt-1">با کلیک بر روی دکمه، فرآیند دریافت و همگام‌سازی کتاب‌ها از منبع خارجی آغاز می‌شود. این فرآیند ممکن است زمان‌بر باشد.</p>
+            <label for="page" class="block text-sm font-medium text-gray-700">همگام‌سازی یک صفحه خاص</label>
+            <input type="number" id="page" v-model.number="page"
+                   class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                   placeholder="مثال: 5">
           </div>
+
+          <!-- Sync Page Range -->
+          <div class="md:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <label for="start_page" class="block text-sm font-medium text-gray-700">صفحه شروع</label>
+              <input type="number" id="start_page" v-model.number="start_page"
+                     class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                     placeholder="مثال: 1">
+            </div>
+            <div>
+              <label for="end_page" class="block text-sm font-medium text-gray-700">صفحه پایان</label>
+              <input type="number" id="end_page" v-model.number="end_page"
+                     class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                     placeholder="مثال: 10">
+            </div>
+          </div>
+        </div>
+        <p class="text-xs text-gray-500">
+          <strong>توجه:</strong> اگر "صفحه خاص" پر شود، گزینه‌های "صفحه شروع" و "صفحه پایان" نادیده گرفته می‌شوند. اگر همه فیلدها خالی باشند، تمام کتاب‌ها همگام‌سازی خواهند شد.
+        </p>
+
+        <!-- Action Button -->
+        <div class="flex items-center justify-end border-t border-gray-200 pt-6">
           <button @click="syncBooks"
                   :disabled="isSyncing"
                   class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white"
@@ -46,13 +80,27 @@ const isSyncing = ref(false)
 const message = ref('')
 const messageType = ref('') // 'success' or 'error'
 
+const page = ref(null)
+const start_page = ref(null)
+const end_page = ref(null)
+
 const syncBooks = async () => {
   isSyncing.value = true
   message.value = ''
   messageType.value = ''
 
+  let requestBody = {}
+  if (page.value) {
+    requestBody = { page: page.value }
+  } else if (start_page.value || end_page.value) {
+    requestBody = {
+      start_page: start_page.value,
+      end_page: end_page.value
+    }
+  }
+
   try {
-    const response = await api.post('/admin/books/sync-from-api')
+    const response = await api.post('/admin/books/sync-from-api', requestBody)
     if (response.success) {
       message.value = response.message || 'فرآیند همگام‌سازی کتاب‌ها با موفقیت آغاز شد.'
       messageType.value = 'success'


### PR DESCRIPTION
Updates the admin book sync page to allow specifying a single page or a range of pages for synchronization.

This addresses the user's follow-up request to have more granular control over the book import process.

The UI now includes input fields for:
- A single page number
- A start and end page number

The component's logic constructs the API request body based on these inputs, sending an empty body to sync all books if no pages are specified.