### PR TITLE
Fix: Use correct endpoint for book synchronization

### DIFF
--- a/app/pages/admin/fetch-books.vue
+++ b/app/pages/admin/fetch-books.vue
@@ -100,7 +100,7 @@ const syncBooks = async () => {
   }
 
   try {
-    const response = await api.post('/admin/books/sync-from-api', requestBody)
+    const response = await api.post('/admin/importer/sync', requestBody)
     if (response.success) {
       message.value = response.message || 'فرآیند همگام‌سازی کتاب‌ها با موفقیت آغاز شد.'
       messageType.value = 'success'


### PR DESCRIPTION
The admin page for fetching books was making a POST request to `/api/v1/admin/books/sync-from-api`, which was incorrect. This caused a 'Method Not Supported' error from the backend.

This change updates the API call to use the correct endpoint, `/api/v1/admin/importer/sync`, as demonstrated by the working curl command provided in the issue description.