### PR TITLE
fix: Correct download link format in admin orders

### DIFF
--- a/app/pages/admin/orders.vue
+++ b/app/pages/admin/orders.vue
@@ -113,7 +113,7 @@
                 <template v-for="item in order.items" :key="item.id">
                   <NuxtLink
                     v-if="item.purchase && item.purchase.download_token"
-                    :to="`/download/book/${item.purchase.download_token}`"
+                    :to="`/book/download/${item.purchase.download_token}`"
                     target="_blank"
                     class="p-1 text-blue-600 hover:text-blue-800 rounded-full hover:bg-gray-200 transition-colors"
                     title="دانلود فایل"


### PR DESCRIPTION
This commit corrects the URL structure for the download link on the admin orders page. The previous format was `/download/book/{token}`, and it has been corrected to `/book/download/{token}` as per the user's feedback.