### PR TITLE
refactor: Remove reactivate order button and logic

### DIFF
--- a/app/pages/admin/orders.vue
+++ b/app/pages/admin/orders.vue
@@ -142,23 +142,6 @@
                   </svg>
                 </button>
 
-                <!-- Reactivate Button -->
-                <button
-                  v-if="isReactivatable(order)"
-                  @click="reactivateOrder(order)"
-                  :disabled="processingOrders[order.id]"
-                  class="p-1 text-green-600 hover:text-green-800 rounded-full hover:bg-gray-200 transition-colors disabled:opacity-50"
-                  title="بازسازی"
-                >
-                  <svg v-if="!processingOrders[order.id]" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h5M20 20v-5h-5M4 4l5 5M20 20l-5-5" />
-                  </svg>
-                  <!-- Spinner Icon -->
-                  <svg v-else class="animate-spin h-5 w-5 text-green-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                  </svg>
-                </button>
               </div>
             </td>
           </tr>
@@ -241,30 +224,6 @@ const expireOrder = async (order) => {
 const isExpirable = (order) => {
   if (!order || !order.items) return false;
   return order.items.some(item => item.purchase && item.purchase.status === 'active');
-};
-
-const isReactivatable = (order) => {
-  if (!order || !order.items) return false;
-  const hasExpired = order.items.some(item => item.purchase && item.purchase.status === 'expired');
-  const hasActive = order.items.some(item => item.purchase && item.purchase.status === 'active');
-  return hasExpired && !hasActive;
-};
-
-const reactivateOrder = async (order) => {
-  if (!confirm(`آیا از بازسازی سفارش شماره ${order.order_number} اطمینان دارید؟`)) {
-    return;
-  }
-
-  processingOrders.value[order.id] = true;
-  try {
-    await api.post(`/admin/orders/${order.id}/reactivate`);
-    await fetchOrders(pagination.value.currentPage);
-  } catch (err) {
-    console.error(`Failed to reactivate order ${order.id}:`, err);
-    alert('بازسازی سفارش با خطا مواجه شد.');
-  } finally {
-    processingOrders.value[order.id] = false;
-  }
 };
 
 const fetchOrders = async (page = 1) => {


### PR DESCRIPTION
This commit removes the "Reactivate Order" functionality from the admin orders page, as requested by the user.

- Removed the "Reactivate" button from the template.
- Removed the `reactivateOrder` and `isReactivatable` functions from the script.