### PR TITLE
refactor: Adjust fullscreen image to cover the screen

### DIFF
--- a/app/pages/admin/gallery/index.vue
+++ b/app/pages/admin/gallery/index.vue
@@ -136,8 +136,8 @@
     </div>
 
     <!-- Fullscreen Image Viewer -->
-    <div v-if="fullscreenImageUrl" @click="hideFullscreen" class="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50 cursor-pointer">
-      <img :src="fullscreenImageUrl" class="max-w-full max-h-full object-contain">
+    <div v-if="fullscreenImageUrl" @click="hideFullscreen" class="fixed inset-0 bg-black z-50 cursor-pointer">
+      <img :src="fullscreenImageUrl" class="w-full h-full object-cover">
     </div>
   </div>
 </template>


### PR DESCRIPTION
Based on user feedback, this commit updates the fullscreen image viewer. The image now uses `object-cover` to ensure it fills the entire screen for a more immersive review experience, even if it means cropping parts of the image.

This follows the initial implementation that made the gallery fullscreen and improved the image grid.

Key changes:
- Updated the fullscreen image style from `object-contain` to `object-cover`.
- Removed `bg-opacity-80` to have a solid black background.
- Removed `flex items-center justify-center` as it's no longer needed.