### PR TITLE
fix: Create SafeImage component to prevent image loading loops

### DIFF
--- a/app/components/BookCard.vue
+++ b/app/components/BookCard.vue
@@ -2,10 +2,12 @@
   <div class="bg-white rounded-lg shadow hover:shadow-lg transition h-full flex flex-col">
     <NuxtLink :to="`/book/${book.slug}`" class="block">
       <div class="relative">
-        <img :src="book.cover_image_url || '/images/placeholders/book-placeholder-thumb.jpg'"
-             :alt="book.title"
-             @error="$event.target.src='/images/placeholders/book-placeholder-thumb.jpg'"
-             class="w-full h-48 object-cover rounded-t-lg">
+        <SafeImage
+          :src="book.cover_image_url"
+          :alt="book.title"
+          fallback-src="/images/placeholders/book-placeholder-thumb.jpg"
+          class="w-full h-48 object-cover rounded-t-lg"
+        />
         <div v-if="book.discount_percent"
              class="absolute top-2 left-2 bg-red-500 text-white px-2 py-1 rounded text-xs">
           {{ book.discount_percent }}% تخفیف
@@ -67,7 +69,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import SafeImage from '~/components/SafeImage.vue';
 
 const props = defineProps({
   book: {
@@ -83,5 +85,4 @@ const props = defineProps({
 const formatPrice = (price) => {
   return new Intl.NumberFormat('fa-IR').format(price) + ' تومان';
 };
-
 </script>

--- a/app/components/SafeImage.vue
+++ b/app/components/SafeImage.vue
@@ -1,0 +1,39 @@
+<template>
+  <img :src="currentSrc" :alt="alt" @error="handleError" />
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+
+const props = defineProps({
+  src: {
+    type: String,
+    default: ''
+  },
+  alt: {
+    type: String,
+    default: ''
+  },
+  fallbackSrc: {
+    type: String,
+    required: true
+  }
+});
+
+const currentSrc = ref(props.src || props.fallbackSrc);
+const hasTriedFallback = ref(false);
+
+watch(() => props.src, (newSrc) => {
+  currentSrc.value = newSrc || props.fallbackSrc;
+  hasTriedFallback.value = false;
+});
+
+const handleError = () => {
+  if (!hasTriedFallback.value) {
+    hasTriedFallback.value = true;
+    currentSrc.value = props.fallbackSrc;
+  }
+  // If the fallback also fails, the error event will be triggered again,
+  // but since hasTriedFallback is true, we won't enter an infinite loop.
+};
+</script>

--- a/app/pages/admin/gallery/index.vue
+++ b/app/pages/admin/gallery/index.vue
@@ -62,11 +62,13 @@
         <div v-if="images.length > 0" class="grid grid-cols-4 gap-2">
           <template v-for="image in images" :key="image.id">
             <div class="relative border-2 border-gray-300 rounded-lg overflow-hidden shadow-sm">
-              <img :src="image.thumbnail_url || image.url || '/images/placeholders/book-placeholder-thumb.jpg'"
-                   :alt="image.book.title"
-                   @error="$event.target.src='/images/placeholders/book-placeholder-thumb.jpg'"
-                   class="w-full h-64 object-cover cursor-pointer"
-                   @click="showFullscreen(image.url || image.thumbnail_url)">
+              <SafeImage
+                :src="image.thumbnail_url || image.url"
+                :alt="image.book.title"
+                fallback-src="/images/placeholders/book-placeholder-thumb.jpg"
+                class="w-full h-64 object-cover cursor-pointer"
+                @click="showFullscreen(image.url || image.thumbnail_url)"
+              />
               <div class="p-2">
                 <h3 class="text-sm font-medium truncate">{{ image.book.title }}</h3>
                 <div class="flex justify-center gap-2 mt-2">
@@ -90,11 +92,13 @@
         <div v-if="approvedImages.length > 0" class="grid grid-cols-4 gap-2">
           <template v-for="image in approvedImages" :key="image.id">
             <div class="relative border-2 border-green-300 rounded-lg overflow-hidden shadow-sm">
-              <img :src="image.thumbnail_url || image.url || '/images/placeholders/book-placeholder-thumb.jpg'"
-                   :alt="image.book.title"
-                   @error="$event.target.src='/images/placeholders/book-placeholder-thumb.jpg'"
-                   class="w-full h-64 object-cover cursor-pointer"
-                   @click="showFullscreen(image.url || image.thumbnail_url)">
+              <SafeImage
+                :src="image.thumbnail_url || image.url"
+                :alt="image.book.title"
+                fallback-src="/images/placeholders/book-placeholder-thumb.jpg"
+                class="w-full h-64 object-cover cursor-pointer"
+                @click="showFullscreen(image.url || image.thumbnail_url)"
+              />
               <div class="p-2">
                 <h3 class="text-sm font-medium truncate">{{ image.book.title }}</h3>
                 <button
@@ -120,11 +124,13 @@
         <div v-if="rejectedImages.length > 0" class="grid grid-cols-4 gap-2">
           <template v-for="image in rejectedImages" :key="image.id">
             <div class="relative border-2 border-red-300 rounded-lg overflow-hidden shadow-sm">
-              <img :src="image.thumbnail_url || image.url || '/images/placeholders/book-placeholder-thumb.jpg'"
-                   :alt="image.book.title"
-                   @error="$event.target.src='/images/placeholders/book-placeholder-thumb.jpg'"
-                   class="w-full h-64 object-cover cursor-pointer"
-                   @click="showFullscreen(image.url || image.thumbnail_url)">
+              <SafeImage
+                :src="image.thumbnail_url || image.url"
+                :alt="image.book.title"
+                fallback-src="/images/placeholders/book-placeholder-thumb.jpg"
+                class="w-full h-64 object-cover cursor-pointer"
+                @click="showFullscreen(image.url || image.thumbnail_url)"
+              />
               <div class="p-2">
                 <h3 class="text-sm font-medium truncate">{{ image.book.title }}</h3>
                 <p class="text-xs text-gray-500 mt-1">دلیل رد: {{ image.rejection_reason }}</p>
@@ -157,6 +163,7 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import { useApiAuth } from '~/composables/useApiAuth'
+import SafeImage from '~/components/SafeImage.vue'
 
 definePageMeta({
   layout: 'fullscreen',


### PR DESCRIPTION
This commit introduces a new reusable component, `SafeImage.vue`, to provide a robust solution for displaying images with fallbacks, completely resolving the infinite network request loop bug.

**Problem:**
- Binding `<img>`'s `:src` to a potentially invalid URL and using `@error` to set a fallback `src` caused an infinite loop if the fallback itself failed to load.
- This resulted in constant network requests, high resource consumption, and flickering UI in the admin gallery.

**Solution:**
1.  **Created `SafeImage.vue` Component:**
    -   A new component at `app/components/SafeImage.vue` is created.
    -   It accepts `src`, `alt`, and `fallback-src` props.
    -   It internally manages the loading state and only attempts to load the fallback image *once* upon error, preventing any possibility of an infinite loop.

2.  **Refactored `BookCard.vue`:**
    -   Replaced the native `<img>` tag with the new `<SafeImage>` component.
    -   This simplifies the `BookCard` component by offloading the complex error handling logic.

3.  **Refactored `admin/gallery/index.vue`:**
    -   Replaced all `<img>` tags across all three tabs (Pending, Approved, Rejected) with the `<SafeImage>` component.
    -   This fixes the network loop bug and ensures images (or their fallbacks) are displayed correctly and efficiently.

This architectural improvement not only fixes the critical bug but also enhances code reusability and maintainability for future image handling needs.