### PR TITLE
feat: Redirect user to previous page after login

### DIFF
--- a/app/pages/auth.vue
+++ b/app/pages/auth.vue
@@ -120,6 +120,7 @@ definePageMeta({
 
 const authStore = useAuthStore()
 const router = useRouter()
+const route = useRoute()
 const formatters = useFormatters()
 
 type UiState = 'identifier' | 'register' | 'password' | 'otp'
@@ -218,7 +219,8 @@ const handleLoginWithPassword = async () => {
   loading.value = true
   try {
     await authStore.loginWithPassword(identifier.value, password.value)
-    await router.push('/dashboard')
+    const redirectPath = route.query.redirect?.toString() || '/dashboard'
+    await router.push(redirectPath)
   } catch (err: any) {
     error.value = err.data?.message || 'شناسه یا رمز عبور اشتباه است.'
   } finally {
@@ -253,7 +255,8 @@ const handleVerifyOtp = async () => {
   try {
     const nameToSend = checkUserResponse.value?.user_exists ? undefined : userName.value
     await authStore.verifyOtp(identifier.value, otp.value, nameToSend)
-    await router.push('/dashboard')
+    const redirectPath = route.query.redirect?.toString() || '/dashboard'
+    await router.push(redirectPath)
   } catch (err: any) {
     error.value = err.data?.message || 'کد تایید اشتباه است.'
   } finally {

--- a/app/pages/book/[slug].vue
+++ b/app/pages/book/[slug].vue
@@ -99,7 +99,7 @@
               <!-- Sub-case: Guest clicked "Buy", show login prompt -->
               <div v-if="showLoginPrompt" class="text-center p-4 bg-gray-100 rounded-lg">
                 <p class="font-semibold mb-3">برای خرید این کتاب، لطفاً ابتدا وارد حساب کاربری خود شوید.</p>
-                <NuxtLink to="/auth" class="inline-block bg-blue-600 text-white font-bold py-2 px-6 rounded-lg hover:bg-blue-700 transition">
+                <NuxtLink :to="`/auth?redirect=${route.fullPath}`" class="inline-block bg-blue-600 text-white font-bold py-2 px-6 rounded-lg hover:bg-blue-700 transition">
                   ورود یا ثبت‌نام
                 </NuxtLink>
               </div>


### PR DESCRIPTION
When a user on a book page clicks "buy" and is redirected to the login page, they are now returned to the original book page after a successful login.

This is achieved by passing the current path as a 'redirect' query parameter to the auth page. The auth page logic is updated to use this 'redirect' parameter for navigation after login, defaulting to '/dashboard' if the parameter is not present.